### PR TITLE
OPTIM: Treated warnings as errors for HashTests project.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,9 +176,9 @@ set_target_properties(HashTests PROPERTIES FOLDER "Tests")
 # Non-example code which require _DEBUG is dealed separately when
 # building the specific libraries.
 if (MSVC)
-	target_compile_options(HashTests PRIVATE "/D_CRT_SECURE_NO_WARNINGS")
+	target_compile_options(HashTests PRIVATE "/D_CRT_SECURE_NO_WARNINGS" "/WX")
 endif()
 
 if (CMAKE_COMPILER_IS_GNUCC)
-	target_compile_options(HashTests PRIVATE "-Wall" "-Wno-unused-variable" "-Wno-unused-result" "-Wno-unused-but-set-variable")
+	target_compile_options(HashTests PRIVATE "-Wall" "-Werror" "-Wno-unused-variable" "-Wno-unused-result" "-Wno-unused-but-set-variable")
 endif()


### PR DESCRIPTION
Changes included:
- Treat all warnings as errors for CommonTests project

NOTE:
- Please run this through CI before complete the merge
- Also, there are warnings in gtest.h included in the development Visual Studio solution. Since this is the 3rd party library, we don't have much control over. Adding a comment to refer to this in the project file is not optimal since developer does not often look at the project file. Therefore, the best way is to continue keep track of warning error vi CMake project which already treats warnings as errors in this PR.