### PR TITLE
Fix compilation with nginx module v4

### DIFF
--- a/src/hash/hash.c
+++ b/src/hash/hash.c
@@ -1344,7 +1344,8 @@ static void initGetEvidencePropertyRelated(
 	DataReset(&propertyItem.data);
 	DataReset(&nameItem.data);
 	int propertiesCount = CollectionGetCount(dataSet->properties);
-	for (int propertyIndex = 0; 
+	int propertyIndex;
+	for (propertyIndex = 0;
 		propertyIndex < propertiesCount && EXCEPTION_OKAY; 
 		propertyIndex++) {
 		property = PropertyGet(
@@ -2259,7 +2260,8 @@ void fiftyoneDegreesResultsHashFromEvidence(
 		// situations where a User-Agent that is provided by the calling
 		// application can be used in preference to the one associated with the
 		// calling device.
-		for (int i = 0;
+		int i;
+		for (i = 0;
 			i < FIFTYONE_DEGREES_ORDER_OF_PRECEDENCE_SIZE &&
 			results->count == 0;
 			i++) {
@@ -2393,7 +2395,8 @@ createPseudoEvidenceKeyValueArray(
 				(void*)Malloc(
 					pseudoEvidence->capacity * maxUaLength);
 			if (evidenceMem != NULL) {
-				for (uint32_t i = 0; i < pseudoEvidence->capacity; i++) {
+				uint32_t i;
+				for (i = 0; i < pseudoEvidence->capacity; i++) {
 					pseudoEvidence->items[i].field = NULL;
 					pseudoEvidence->items[i].originalValue =
 						(void*)((char*)evidenceMem + i * maxUaLength);


### PR DESCRIPTION
When trying to compile the new nginx v4 module, I bumped into a few errors such as this one:
```
device-detection-nginx-4.3.0/51Degrees_module/src/hash/hash.c: In function 'initGetEvidencePropertyRelated':
device-detection-nginx-4.3.0/51Degrees_module/src/hash/hash.c:1347:2: error: 'for' loop initial declarations are only allowed in C99 mode
  for (int propertyIndex = 0; 
  ^
device-detection-nginx-4.3.0/51Degrees_module/src/hash/hash.c:1347:2: note: use option -std=c99 or -std=gnu99 to compile your code
```
I initially tried adding `-std=c99` to the build as instructed, and these errors went away, but then another 3rd party module I also compile into nginx starting failing to compile ([naxsi](https://github.com/nbs-system/naxsi/wiki)). These trivial declaration changes now make everything compile just fine with the default CFLAGS that the Fedora and Red Hat packages are using (some similar occurrences also need to be fixed in common-cxx).