### PR TITLE
EXAMPLE/BUG: The getting started example used IsMobile as the property regardless of the input.

### DIFF
--- a/examples/C/Hash/GettingStarted.c
+++ b/examples/C/Hash/GettingStarted.c
@@ -117,7 +117,7 @@ static void outputValue(
 	DataSetHash* dataset = (DataSetHash*)results->b.b.dataSet;
 
 	EXCEPTION_CREATE;
-	int propertyIndex = PropertiesGetPropertyIndexFromName(dataset->b.b.available, "IsMobile");
+	int propertyIndex = PropertiesGetPropertyIndexFromName(dataset->b.b.available, propertyName);
 	// If a value has not been set then trying to access the value will
 	// result in an exception.
 	if (ResultsHashGetHasValues(


### PR DESCRIPTION
This has now been changed to use the property name provided to the `outputValue` method.
Closes #13