### PR TITLE
confined use of std

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
-set (CMAKE_C_STANDARD 11)
-set (CMAKE_CXX_STANDARD 11)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 
 # Include the common API
 

--- a/examples/CPP/Hash/ExampleBase.hpp
+++ b/examples/CPP/Hash/ExampleBase.hpp
@@ -34,7 +34,8 @@ static const char *dataFileName = "51Degrees-LiteV4.1.hash";
 
 static const char *userAgentFileName = "20000 User Agents.csv";
 
-using namespace std;
+using std::cout;
+using std::thread;
 using namespace FiftyoneDegrees::Common;
 using namespace FiftyoneDegrees::DeviceDetection::Hash;
 

--- a/examples/CPP/Hash/GettingStarted.cpp
+++ b/examples/CPP/Hash/GettingStarted.cpp
@@ -28,7 +28,6 @@
 #include "../../../src/hash/EngineHash.hpp"
 #include "ExampleBase.hpp"
 
-using namespace std;
 using namespace FiftyoneDegrees::Common;
 using namespace FiftyoneDegrees::DeviceDetection;
 using namespace FiftyoneDegrees::DeviceDetection::Hash;

--- a/examples/CPP/Hash/ReloadFromMemory.cpp
+++ b/examples/CPP/Hash/ReloadFromMemory.cpp
@@ -29,7 +29,6 @@
 #include "../../../src/hash/EngineHash.hpp"
 #include "ExampleBase.hpp"
 
-using namespace std;
 using namespace FiftyoneDegrees::Common;
 using namespace FiftyoneDegrees::DeviceDetection;
 using namespace FiftyoneDegrees::DeviceDetection::Hash;

--- a/src/ConfigDeviceDetection.hpp
+++ b/src/ConfigDeviceDetection.hpp
@@ -27,7 +27,6 @@
 #include "common-cxx/ConfigBase.hpp"
 #include "config-dd.h"
 
-using namespace std;
 using namespace FiftyoneDegrees::Common;
 
 namespace FiftyoneDegrees {

--- a/src/hash/ComponentMetaDataBuilderHash.hpp
+++ b/src/hash/ComponentMetaDataBuilderHash.hpp
@@ -28,7 +28,6 @@
 #include "../common-cxx/EntityMetaDataBuilder.hpp"
 #include "hash.h"
 
-using namespace std;
 using namespace FiftyoneDegrees::Common;
 
 namespace FiftyoneDegrees {

--- a/src/hash/ComponentMetaDataCollectionHash.hpp
+++ b/src/hash/ComponentMetaDataCollectionHash.hpp
@@ -27,7 +27,6 @@
 #include "ComponentMetaDataBuilderHash.hpp"
 #include "hash.h"
 
-using namespace std;
 using namespace FiftyoneDegrees::Common;
 
 namespace FiftyoneDegrees {

--- a/src/hash/ConfigHash.hpp
+++ b/src/hash/ConfigHash.hpp
@@ -18,6 +18,7 @@
  * including the attribution notice(s) required under Article 5 of the EUPL
  * in the end user terms of the application under an appropriate heading,
  * such notice(s) shall fulfill the requirements of that article.
+ * such notice(s) shall fulfill the requirements of that article.
  * ********************************************************************* */
 
 #ifndef FIFTYONE_DEGREES_CONFIG_HASH_HPP
@@ -27,7 +28,7 @@
 #include "../ConfigDeviceDetection.hpp"
 #include "hash.h"
 
-using namespace std;
+using std::min_element;
 using namespace FiftyoneDegrees::Common;
 
 namespace FiftyoneDegrees {

--- a/src/hash/ConfigHash.hpp
+++ b/src/hash/ConfigHash.hpp
@@ -18,7 +18,6 @@
  * including the attribution notice(s) required under Article 5 of the EUPL
  * in the end user terms of the application under an appropriate heading,
  * such notice(s) shall fulfill the requirements of that article.
- * such notice(s) shall fulfill the requirements of that article.
  * ********************************************************************* */
 
 #ifndef FIFTYONE_DEGREES_CONFIG_HASH_HPP

--- a/src/hash/EngineHash.hpp
+++ b/src/hash/EngineHash.hpp
@@ -34,7 +34,6 @@
 #include "ResultsHash.hpp"
 #include "MetaDataHash.hpp"
 
-using namespace std;
 using namespace FiftyoneDegrees::Common;
 
 namespace FiftyoneDegrees {

--- a/src/hash/ProfileMetaDataBuilderHash.hpp
+++ b/src/hash/ProfileMetaDataBuilderHash.hpp
@@ -28,7 +28,6 @@
 #include "../common-cxx/EntityMetaDataBuilder.hpp"
 #include "hash.h"
 
-using namespace std;
 using namespace FiftyoneDegrees::Common;
 
 namespace FiftyoneDegrees {

--- a/src/hash/ProfileMetaDataCollectionHash.hpp
+++ b/src/hash/ProfileMetaDataCollectionHash.hpp
@@ -27,7 +27,6 @@
 #include "ProfileMetaDataBuilderHash.hpp"
 #include "hash.h"
 
-using namespace std;
 using namespace FiftyoneDegrees::Common;
 
 namespace FiftyoneDegrees {

--- a/src/hash/PropertyMetaDataBuilderHash.hpp
+++ b/src/hash/PropertyMetaDataBuilderHash.hpp
@@ -28,7 +28,6 @@
 #include "../common-cxx/EntityMetaDataBuilder.hpp"
 #include "hash.h"
 
-using namespace std;
 using namespace FiftyoneDegrees::Common;
 
 namespace FiftyoneDegrees {

--- a/src/hash/PropertyMetaDataCollectionForComponentHash.cpp
+++ b/src/hash/PropertyMetaDataCollectionForComponentHash.cpp
@@ -24,6 +24,7 @@
 #include "../common-cxx/Exceptions.hpp"
 #include "fiftyone.h"
 
+using std::shared_ptr;
 using namespace FiftyoneDegrees::DeviceDetection::Hash;
 
 PropertyMetaDataCollectionForComponentHash::PropertyMetaDataCollectionForComponentHash(

--- a/src/hash/PropertyMetaDataCollectionForComponentHash.hpp
+++ b/src/hash/PropertyMetaDataCollectionForComponentHash.hpp
@@ -31,7 +31,6 @@
 #include "hash.h"
 #include <memory>
 
-using namespace std;
 using namespace FiftyoneDegrees::Common;
 
 namespace FiftyoneDegrees {

--- a/src/hash/PropertyMetaDataCollectionForPropertyHash.hpp
+++ b/src/hash/PropertyMetaDataCollectionForPropertyHash.hpp
@@ -29,7 +29,6 @@
 #include "hash.h"
 #include <memory>
 
-using namespace std;
 using namespace FiftyoneDegrees::Common;
 
 namespace FiftyoneDegrees {

--- a/src/hash/PropertyMetaDataCollectionHash.hpp
+++ b/src/hash/PropertyMetaDataCollectionHash.hpp
@@ -27,7 +27,6 @@
 #include "PropertyMetaDataBuilderHash.hpp"
 #include "hash.h"
 
-using namespace std;
 using namespace FiftyoneDegrees::Common;
 
 namespace FiftyoneDegrees {

--- a/src/hash/ResultsHash.hpp
+++ b/src/hash/ResultsHash.hpp
@@ -27,7 +27,6 @@
 #include "../ResultsDeviceDetection.hpp"
 #include "hash.h"
 
-using namespace std;
 
 class EngineHashTests;
 

--- a/src/hash/ValueMetaDataBuilderHash.hpp
+++ b/src/hash/ValueMetaDataBuilderHash.hpp
@@ -28,8 +28,6 @@
 #include "../common-cxx/EntityMetaDataBuilder.hpp"
 #include "hash.h"
 
-using namespace std;
-
 using namespace FiftyoneDegrees::Common;
 
 namespace FiftyoneDegrees {

--- a/src/hash/ValueMetaDataCollectionBaseHash.hpp
+++ b/src/hash/ValueMetaDataCollectionBaseHash.hpp
@@ -27,7 +27,6 @@
 #include "ValueMetaDataBuilderHash.hpp"
 #include "hash.h"
 
-using namespace std;
 using namespace FiftyoneDegrees::Common;
 
 namespace FiftyoneDegrees {

--- a/src/hash/ValueMetaDataCollectionForProfileHash.hpp
+++ b/src/hash/ValueMetaDataCollectionForProfileHash.hpp
@@ -29,7 +29,6 @@
 #include "ValueMetaDataBuilderHash.hpp"
 #include "hash.h"
 
-using namespace std;
 using namespace FiftyoneDegrees::Common;
 
 namespace FiftyoneDegrees {

--- a/src/hash/ValueMetaDataCollectionForPropertyHash.hpp
+++ b/src/hash/ValueMetaDataCollectionForPropertyHash.hpp
@@ -29,7 +29,6 @@
 #include "ValueMetaDataBuilderHash.hpp"
 #include "hash.h"
 
-using namespace std;
 using namespace FiftyoneDegrees::Common;
 
 namespace FiftyoneDegrees {

--- a/src/hash/ValueMetaDataCollectionHash.hpp
+++ b/src/hash/ValueMetaDataCollectionHash.hpp
@@ -27,7 +27,6 @@
 #include "ValueMetaDataBuilderHash.hpp"
 #include "hash.h"
 
-using namespace std;
 using namespace FiftyoneDegrees::Common;
 
 namespace FiftyoneDegrees {

--- a/test/EngineDeviceDetectionTests.cpp
+++ b/test/EngineDeviceDetectionTests.cpp
@@ -31,6 +31,9 @@
 #endif
 #endif
 
+using std::ofstream;
+using std::endl;
+
 EngineDeviceDetectionTests::EngineDeviceDetectionTests(
 	RequiredPropertiesConfig *requiredProperties,
 	const char *directory,

--- a/test/hash/EngineHashInitTests.cpp
+++ b/test/hash/EngineHashInitTests.cpp
@@ -26,6 +26,10 @@
 #include <iostream>
 #include <fstream>
 
+using std::ifstream;
+using std::ofstream;
+using std::ios;
+
 using namespace FiftyoneDegrees::Common;
 using namespace FiftyoneDegrees::DeviceDetection;
 using namespace FiftyoneDegrees::DeviceDetection::Hash;


### PR DESCRIPTION
To resolve the name collision of `std::byte` and `typedef unsigned char byte;` when building with C++17. The motivation for building with C++17 is that Node 20 bindings require switching to C++17.  

CMakeLists.txt in this repo specifies: 

```
set (CMAKE_CXX_STANDARD 17)
```
however this is redundant, since there is 
```
include(${CMAKE_CURRENT_LIST_DIR}/src/common-cxx/CMakeLists.txt NO_POLICY_SCOPE)
```
and CMakeLists as part of `common-cxx` also has 
```
set (CMAKE_CXX_STANDARD 17)
```
So it will override whatever setting is specified above.