### PR TITLE
BUG/MINOR: Fix limiting properties available in example.

### DIFF
--- a/examples/C/Hash/GettingStarted.c
+++ b/examples/C/Hash/GettingStarted.c
@@ -117,11 +117,13 @@ static void outputValue(
 	DataSetHash* dataset = (DataSetHash*)results->b.b.dataSet;
 
 	EXCEPTION_CREATE;
-	int propertyIndex = PropertiesGetPropertyIndexFromName(dataset->b.b.available, propertyName);
+	int requiredPropertyIndex = PropertiesGetRequiredPropertyIndexFromName(
+		dataset->b.b.available, 
+		propertyName);
 	// If a value has not been set then trying to access the value will
 	// result in an exception.
 	if (ResultsHashGetHasValues(
-		results, propertyIndex, exception)) {
+		results, requiredPropertyIndex, exception)) {
 		ResultsHashGetValuesString(
 			results,
 			propertyName,
@@ -135,7 +137,7 @@ static void outputValue(
 		// A no value message can also be obtained. This message describes why
 		// the value has not been set.
 		fiftyoneDegreesResultsNoValueReason reason =
-			ResultsHashGetNoValueReason(results, propertyIndex, exception);
+			ResultsHashGetNoValueReason(results, requiredPropertyIndex, exception);
 		EXCEPTION_THROW;
 
 		sprintf(valueBuffer, "Unknown (%s)", ResultsHashGetNoValueReasonMessage(reason));


### PR DESCRIPTION
If the PropertiesRequired string parameter is set to limit the properties and components that are used in the device detection operation then random values would be returned. This change uses the GetRequiredPropertyIndex method to resolve the index of the property name to address this problem. In example as provided this was not a problem as there were no limits placed on the available properties. It would however confuse a developer seeking to limit the returned properties.