### PR TITLE
Fix bug in offline example when a specific set of properties is provided.

### DIFF
--- a/examples/C/Hash/OfflineProcessing.c
+++ b/examples/C/Hash/OfflineProcessing.c
@@ -136,7 +136,7 @@ static void outputValue(
 		// A no value message can also be obtained. This message describes why
 		// the value has not been set.
 		fiftyoneDegreesResultsNoValueReason reason =
-			ResultsHashGetNoValueReason(results, propertyIndex, exception);
+			ResultsHashGetNoValueReason(results, requiredIndex, exception);
 		EXCEPTION_THROW;
 
 		sprintf(valueBuffer, "Unknown (%s)", ResultsHashGetNoValueReasonMessage(reason));

--- a/examples/C/Hash/OfflineProcessing.c
+++ b/examples/C/Hash/OfflineProcessing.c
@@ -115,13 +115,14 @@ static void outputValue(
 	const char* propertyName,
 	FILE *output) {
 	DataSetHash* dataset = (DataSetHash*)results->b.b.dataSet;
-
+	int requiredIndex = PropertiesGetRequiredPropertyIndexFromName(
+		dataset->b.b.available,
+		propertyName);
 	EXCEPTION_CREATE;
-	int propertyIndex = PropertiesGetPropertyIndexFromName(dataset->b.b.available, propertyName);
 	// If a value has not been set then trying to access the value will
 	// result in an exception.
 	if (ResultsHashGetHasValues(
-		results, propertyIndex, exception)) {
+		results, requiredIndex, exception)) {
 		ResultsHashGetValuesString(
 			results,
 			propertyName,


### PR DESCRIPTION
If the required properties are set then the original implementation would have returned the wrong index. This change uses required property indexes consistently.