### PR TITLE
Restore testing after msbuild

### DIFF
--- a/.github/workflows/nightly-prs-to-main.yml
+++ b/.github/workflows/nightly-prs-to-main.yml
@@ -12,6 +12,7 @@ jobs:
     uses: 51Degrees/common-ci/.github/workflows/nightly-prs-to-main.yml@main
     with:
       repo-name: ${{ github.event.repository.name }}
+      org-name: ${{ github.event.repository.owner.login }}
     secrets:
       token: ${{ secrets.ACCESS_TOKEN }}
       asset-keys: '{ "DeviceDetection": "${{ secrets.DEVICE_DETECTION_KEY }}", "DeviceDetectionUrl": "${{ secrets.DEVICE_DETECTION_URL }}" }'

--- a/.github/workflows/nightly-publish-main.yml
+++ b/.github/workflows/nightly-publish-main.yml
@@ -12,6 +12,7 @@ jobs:
     uses: 51Degrees/common-ci/.github/workflows/nightly-publish-main.yml@main
     with:
       repo-name: ${{ github.event.repository.name }}
+      org-name: ${{ github.event.repository.owner.login }}
       build-platform: ubuntu-latest
     secrets:
       token: ${{ secrets.ACCESS_TOKEN }}

--- a/ci/options.json
+++ b/ci/options.json
@@ -4,32 +4,28 @@
     "Name": "Windows_VS_x64_Debug",
     "Configuration": "Debug",
     "Arch": "x64",
-    "BuildMethod": "msbuild",
-    "ProjectDir": "VisualStudio"
+    "BuildMethod": "msbuild"
   },
   {
     "Image": "windows-latest",
     "Name": "Windows_VS_x86_Debug",
     "Configuration": "Debug",
     "Arch": "x86",
-    "BuildMethod": "msbuild",
-    "ProjectDir": "VisualStudio"
+    "BuildMethod": "msbuild"
   },
   {
     "Image": "windows-latest",
     "Name": "Windows_VS_x64_Release",
     "Configuration": "Release",
     "Arch": "x64",
-    "BuildMethod": "msbuild",
-    "ProjectDir": "VisualStudio"
+    "BuildMethod": "msbuild"
   },
   {
     "Image": "windows-latest",
     "Name": "Windows_VS_x86_Release",
     "Configuration": "Release",
     "Arch": "x86",
-    "BuildMethod": "msbuild",
-    "ProjectDir": "VisualStudio"
+    "BuildMethod": "msbuild"
   },
   {
     "Image": "windows-latest",

--- a/ci/options.json
+++ b/ci/options.json
@@ -4,28 +4,32 @@
     "Name": "Windows_VS_x64_Debug",
     "Configuration": "Debug",
     "Arch": "x64",
-    "BuildMethod": "msbuild"
+    "BuildMethod": "msbuild",
+    "ProjectDir": "VisualStudio"
   },
   {
     "Image": "windows-latest",
     "Name": "Windows_VS_x86_Debug",
     "Configuration": "Debug",
     "Arch": "x86",
-    "BuildMethod": "msbuild"
+    "BuildMethod": "msbuild",
+    "ProjectDir": "VisualStudio"
   },
   {
     "Image": "windows-latest",
     "Name": "Windows_VS_x64_Release",
     "Configuration": "Release",
     "Arch": "x64",
-    "BuildMethod": "msbuild"
+    "BuildMethod": "msbuild",
+    "ProjectDir": "VisualStudio"
   },
   {
     "Image": "windows-latest",
     "Name": "Windows_VS_x86_Release",
     "Configuration": "Release",
     "Arch": "x86",
-    "BuildMethod": "msbuild"
+    "BuildMethod": "msbuild",
+    "ProjectDir": "VisualStudio"
   },
   {
     "Image": "windows-latest",

--- a/ci/run-unit-tests.ps1
+++ b/ci/run-unit-tests.ps1
@@ -7,24 +7,6 @@ param(
     [string]$BuildMethod = "cmake"
 )
 
-$RepoPath = [IO.Path]::Combine($pwd, $RepoName, $ProjectDir, "build")
-
-Write-Output "Entering '$RepoPath'"
-Push-Location $RepoPath
-
-try {
-
-    Write-Output "Testing $($Options.Name)"
-
-    # Instead of calling the common CTest script, we want to allow the inclusion of tests with Performance in the name.
-    # This is because HighPerformance is the name of a configuration.
-    ctest -C $Configuration -T test --no-compress-output --output-junit "../test-results/unit/$Name.xml" --exclude-regex ".*Example.*"
-}
-finally {
-
-    Write-Output "Leaving '$RepoPath'"
-    Pop-Location
-
-}
+./cxx/run-unit-tests.ps1 -RepoName $RepoName -ProjectDir $ProjectDir -Name $Name -Configuration $Configuration -Arch $Arch -BuildMethod $BuildMethod -ExcludeRegex ".*Example.*"
 
 exit $LASTEXITCODE


### PR DESCRIPTION
- Add `org-name` to some workflow files.
- Restore a call to the common script instead of partial duplication (relies on https://github.com/51Degrees/common-ci/pull/49)