### PR TITLE
`sprintf` deprecation warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 3.5)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 17)
 
+set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
+
 # Include the common API
 
 include(${CMAKE_CURRENT_LIST_DIR}/src/common-cxx/CMakeLists.txt NO_POLICY_SCOPE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.24)
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 17)

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ If you have Visual Studio Code, you'll still need to install the build tools fro
 ### Linux 
 
 You will need:
-- [CMake 3.10](https://cmake.org/) or greater installed to build the project. 
+- [CMake 3.24](https://cmake.org/) or greater installed to build the project. 
 - A C++ compiler which supports C++11. The compiler will and other build tools will be selected by CMake automatically based on your environment.
 
 

--- a/examples/C/Hash/GettingStarted.c
+++ b/examples/C/Hash/GettingStarted.c
@@ -60,6 +60,7 @@ static const char *dataDir = "device-detection-data";
 static const char *dataFileName = "51Degrees-LiteV4.1.hash";
 
 static char valueBuffer[1024] = "";
+static const size_t valueBufferLength = sizeof(valueBuffer) / sizeof(valueBuffer[0]);
 
 typedef struct {
 	uint32_t count;
@@ -128,7 +129,7 @@ static void outputValue(
 			results,
 			propertyName,
 			valueBuffer,
-			sizeof(valueBuffer),
+			valueBufferLength,
 			",",
 			exception);
 		EXCEPTION_THROW;
@@ -140,7 +141,7 @@ static void outputValue(
 			ResultsHashGetNoValueReason(results, requiredPropertyIndex, exception);
 		EXCEPTION_THROW;
 
-		sprintf(valueBuffer, "Unknown (%s)", ResultsHashGetNoValueReasonMessage(reason));
+		snprintf(valueBuffer, valueBufferLength, "Unknown (%s)", ResultsHashGetNoValueReasonMessage(reason));
 	}
 	fprintf(output, "\n\t%s: %s", name, valueBuffer);
 }

--- a/examples/C/Hash/OfflineProcessing.c
+++ b/examples/C/Hash/OfflineProcessing.c
@@ -70,6 +70,7 @@ static const char *dataFileName = "51Degrees-LiteV4.1.hash";
 static const char *evidenceFileName = "20000 Evidence Records.yml";
 
 static char valueBuffer[1024] = "";
+static const size_t valueBufferLength = sizeof(valueBuffer) / sizeof(valueBuffer[0]);
 
 /**
  * CHOOSE THE DEFAULT MEMORY CONFIGURATION BY UNCOMMENTING ONE OF THE FOLLOWING
@@ -127,7 +128,7 @@ static void outputValue(
 			results,
 			propertyName,
 			valueBuffer,
-			sizeof(valueBuffer),
+			valueBufferLength,
 			",",
 			exception);
 		EXCEPTION_THROW;
@@ -139,7 +140,7 @@ static void outputValue(
 			ResultsHashGetNoValueReason(results, requiredIndex, exception);
 		EXCEPTION_THROW;
 
-		sprintf(valueBuffer, "Unknown (%s)", ResultsHashGetNoValueReasonMessage(reason));
+		snprintf(valueBuffer, valueBufferLength, "Unknown (%s)", ResultsHashGetNoValueReasonMessage(reason));
 	}
 	fprintf(output, "%s: %s\n", name, valueBuffer);
 }

--- a/examples/C/Hash/ProcHash.c
+++ b/examples/C/Hash/ProcHash.c
@@ -49,7 +49,7 @@ static void buildString(
 			exception) != NULL && EXCEPTION_OKAY) {
 			value = STRING(results->values.items[0].data.ptr);
 
-			const size_t written = snprintf(
+			const int written = snprintf(
 				output, remainingCapacity,
 				"%s: %s\n",
 				property,

--- a/examples/C/Hash/ProcHash.c
+++ b/examples/C/Hash/ProcHash.c
@@ -37,7 +37,7 @@ static void buildString(
 	int i;
 	const char *property, *value;
 	DataSetHash *dataSet = (DataSetHash*)results->b.b.dataSet;
-	int remainingCapacity = outputLength;
+	long long remainingCapacity = outputLength;
 	for (i = 0; i < (int)dataSet->b.b.available->count; i++) {
 		property = STRING(
 			PropertiesGetNameFromRequiredIndex(

--- a/examples/C/Hash/ProcHash.c
+++ b/examples/C/Hash/ProcHash.c
@@ -31,11 +31,13 @@ static const char *dataFileName = "51Degrees-LiteV4.1.hash";
 
 static void buildString(
 	fiftyoneDegreesResultsHash *results,
-	char *output) {
+	char *output,
+	const size_t outputLength) {
 	EXCEPTION_CREATE;
 	int i;
 	const char *property, *value;
 	DataSetHash *dataSet = (DataSetHash*)results->b.b.dataSet;
+	int remainingCapacity = outputLength;
 	for (i = 0; i < (int)dataSet->b.b.available->count; i++) {
 		property = STRING(
 			PropertiesGetNameFromRequiredIndex(
@@ -46,9 +48,20 @@ static void buildString(
 			i,
 			exception) != NULL && EXCEPTION_OKAY) {
 			value = STRING(results->values.items[0].data.ptr);
-			output = output + sprintf(output, "%s: %s\n",
+
+			const size_t written = snprintf(
+				output, remainingCapacity,
+				"%s: %s\n",
 				property,
 				value);
+			if (written <= 0) {
+				break;
+			}
+			remainingCapacity -= written;
+			if (remainingCapacity <= 0) {
+				break;
+			}
+			output += written;
 		}
 	}
 }
@@ -69,6 +82,8 @@ static void reportStatus(
 static int run(fiftyoneDegreesResourceManager *manager) {
 	EXCEPTION_CREATE;
 	char userAgent[500], output[50000];
+ 	const size_t outputLength = sizeof(output) / sizeof(output[0]);
+
 	int count = 0;
 	ResultsHash *results = ResultsHashCreate(
 		manager,
@@ -85,7 +100,7 @@ static int run(fiftyoneDegreesResourceManager *manager) {
 		EXCEPTION_THROW;
 
 		// Print the values for all the required properties.
-		buildString(results, output);
+		buildString(results, output, outputLength);
 		printf("%s", output);
 
 		count++;

--- a/test/hash/EngineHashTests.cpp
+++ b/test/hash/EngineHashTests.cpp
@@ -560,6 +560,7 @@ public:
 		EvidenceDeviceDetection evidence;
 		const char *evidenceValue = "17779|17470|18092";
 		char expectedDeviceId2[24];
+		const size_t expectedDeviceId2Length = sizeof(expectedDeviceId2) / sizeof(expectedDeviceId2[0]);
 		const char* expectedDeviceId1 = "0-17779-17470-18092";
 		EngineHash *localEngine = (EngineHash*)getEngine();
 
@@ -568,7 +569,7 @@ public:
 		Common::Collection<byte, ComponentMetaData> *components =
 			getEngine()->getMetaData()->getComponents();
 		ComponentMetaData *component = components->getByIndex(0);
-		sprintf(expectedDeviceId2, "%d-17779-17470-18092", component->getDefaultProfileId());
+		snprintf(expectedDeviceId2, expectedDeviceId2Length, "%d-17779-17470-18092", component->getDefaultProfileId());
 
 		// Get a property to check which belongs to the component with no
 		// profile.


### PR DESCRIPTION
### Changes
- Migrate from `sprintf` to `snprintf` ([ref^](https://en.cppreference.com/w/c/io/fprintf)).
- Set [`CMAKE_COMPILE_WARNING_AS_ERROR`](https://cmake.org/cmake/help/latest/prop_tgt/COMPILE_WARNING_AS_ERROR.html) to `ON`.
- Bump minimal [CMake](https://cmake.org/) version to `3.24` (latest release is `3.27.7`).

### Why
- https://github.com/51Degrees/device-detection-cxx/issues/36