### PR TITLE
Fix warnings.

### DIFF
--- a/examples/C/Hash/MemHash.c
+++ b/examples/C/Hash/MemHash.c
@@ -88,9 +88,9 @@ typedef struct t_thread_memory_state {
  * @param state information about the overall performance test
  */
 void printLoadBar(memoryThreadState *state) {
-	int i;
-	int full = state->count / state->main->progress;
-	int empty = (state->main->userAgentsCount - state->count) /
+	long i;
+	const long full = state->count / state->main->progress;
+    const long empty = (state->main->userAgentsCount - state->count) /
 		state->main->progress;
 	printf("\r\t[");
 	for (i = 0; i < full; i++) {


### PR DESCRIPTION
⚠️ Potentially depends on https://github.com/51Degrees/common-cxx/pull/34

### Changes

- Fix `long` to `int` precision loss warning in example.

### Why

- Follows on https://github.com/51Degrees/device-detection-cxx/pull/60 .
- Used as a test bed for https://github.com/51Degrees/common-cxx/pull/34 .
- Potentially addresses https://github.com/51Degrees/device-detection-dotnet/actions/runs/6806663964