### PR TITLE
Fix `__int64` to `size_t` conversion warning on x86.

### DIFF
--- a/examples/C/Hash/ProcHash.c
+++ b/examples/C/Hash/ProcHash.c
@@ -50,7 +50,7 @@ static void buildString(
 			value = STRING(results->values.items[0].data.ptr);
 
 			const int written = snprintf(
-				output, remainingCapacity,
+				output, (size_t)remainingCapacity,
 				"%s: %s\n",
 				property,
 				value);


### PR DESCRIPTION
### Changes
- Add explicit cast.

### Context
- The initial value is of `size_t` type ([ref^](https://github.com/postindustria-tech/device-detection-cxx/blob/main/examples/C/Hash/ProcHash.c#L40)).
- The variable is only ever decreased and checked for underflow ([ref^](https://github.com/postindustria-tech/device-detection-cxx/blob/main/examples/C/Hash/ProcHash.c#L60-L62)).

### Why
- Addresses build failure https://github.com/51Degrees/device-detection-dotnet/actions/runs/6858463974/job/18649269162#step:4:331