### PR TITLE
`query.51D_deviceId` processing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ All the examples are available to run in the `VisualStudio/DeviceDetection.sln` 
 
 |Example|Description|Language|
 |-------|-----------|--------|
-|Getting Started|This example shows how to get set up with a Device Detection Cloud aspect engine and begin using it to process User-Agents.|C / C++|
+|Getting Started|This example shows how to get set up with a Device Detection Cloud aspect engine and begin using it to process User-Agents and Client Hints.<br>Also showcase `query.51D_deviceId` high-priority evidence feature (streamlines profile selection). |C / C++|
 |Match Metrics|This example shows how to view metrics associated with the results of processing with a Device Detection aspect engine using the Hash algorithm.|C / C++|
 |Meta Data|This example shows how to interrogate the meta data associated with the contents of a Device Detection Hash data file.|C++|
 |MemHash|This example measures the memory usage of the Hash algorithm.|C|

--- a/examples/CPP/Hash/GettingStarted.cpp
+++ b/examples/CPP/Hash/GettingStarted.cpp
@@ -203,6 +203,49 @@ namespace FiftyoneDegrees {
 						<< "\n";
 					cout << "   IsMobile: " <<
 						(*results->getValueAsString("IsMobile")).c_str() << "\n";
+
+					if (0) {
+						// Carries out a match for a platform based on device ID.
+						std::string deviceID = results->getDeviceId();
+						cout << "   query.51D_deviceId: " <<
+							deviceID.c_str() << "\n";
+						
+						EvidenceDeviceDetection* evidence2 =
+							new EvidenceDeviceDetection();
+						evidence2->operator[]("header.user-agent")
+							= mobileUserAgent;
+
+						cout << "\nMobile User-Agent: " <<
+							mobileUserAgent << "\n";
+						ResultsHash* results2 = engine->process(evidence2);
+						cout << "   PlatformName: " <<
+							(*results2->getValueAsString("PlatformName")).c_str()
+							<< "\n";
+						cout << "   PlatformVersion: " <<
+							(*results2->getValueAsString("PlatformVersion")).c_str()
+							<< "\n";
+						cout << "   IsMobile: " <<
+							(*results2->getValueAsString("IsMobile")).c_str() << "\n";
+						delete results2;
+
+						cout << "\nMobile User-Agent: " <<
+							mobileUserAgent << "\n";
+						cout << "query.51D_deviceId: " <<
+							deviceID.c_str() << "\n";
+						evidence2->operator[]("query.51D_deviceId")
+							= deviceID.c_str();
+						results2 = engine->process(evidence2);
+						cout << "   PlatformName: " <<
+							(*results2->getValueAsString("PlatformName")).c_str()
+							<< "\n";
+						cout << "   PlatformVersion: " <<
+							(*results2->getValueAsString("PlatformVersion")).c_str()
+							<< "\n";
+						cout << "   IsMobile: " <<
+							(*results2->getValueAsString("IsMobile")).c_str() << "\n";
+						delete results2;
+						delete evidence2;
+					};
 					delete results;
 
 					// Free the evidence.

--- a/examples/CPP/Hash/GettingStarted.cpp
+++ b/examples/CPP/Hash/GettingStarted.cpp
@@ -262,7 +262,8 @@ namespace FiftyoneDegrees {
 
 						evidence2->operator[]("header.user-agent")
 							= mobileUserAgent;
-						evidence2->operator[]("query.51D_deviceId")
+						// case-insensitive
+						evidence2->operator[]("query.51d_dEVIcEiD")
 							= deviceId_hintedHub.c_str();
 
 						ResultsHash* results = engine->process(evidence2);

--- a/examples/CPP/Hash/GettingStarted.cpp
+++ b/examples/CPP/Hash/GettingStarted.cpp
@@ -142,12 +142,23 @@ namespace FiftyoneDegrees {
 					: ExampleBase(dataFilePath, config) {
 				};
 
+				void printResults(ResultsHash* results) {
+					cout << "   PlatformName: " <<
+						(*results->getValueAsString("PlatformName")).c_str()
+						<< "\n";
+					cout << "   PlatformVersion: " <<
+						(*results->getValueAsString("PlatformVersion")).c_str()
+						<< "\n";
+					cout << "   IsMobile: " <<
+						(*results->getValueAsString("IsMobile")).c_str() << "\n";
+					cout << "   Devide ID: " <<
+						results->getDeviceId() << "\n";
+				}
+
 				/**
 				 * @copydoc ExampleBase::run
 				 */
 				void run() {
-					ResultsHash *results;
-
 					// Create an evidence instance to store and process
 					// User-Agents.
 					EvidenceDeviceDetection *evidence =
@@ -155,101 +166,103 @@ namespace FiftyoneDegrees {
 
 					cout << "Starting Getting Started Example.\n";
 
-					// Carries out a match for a mobile User-Agent.
-					cout << "\nMobile User-Agent: " <<
-						 mobileUserAgent << "\n";
-					evidence->operator[]("header.user-agent")
+					std::string deviceId_mobile;
+					{
+						// Carries out a match for a mobile User-Agent.
+						cout << "\n";
+						cout << "Mobile User-Agent: " <<
+							mobileUserAgent << "\n";
+						evidence->operator[]("header.user-agent")
 							= mobileUserAgent;
-					results = engine->process(evidence);
-					cout << "   IsMobile: " <<
-						 (*results->getValueAsString("IsMobile")).c_str() << "\n";
-					delete results;
 
-					// Carries out a match for a desktop User-Agent.
-					cout << "\nDesktop User-Agent: " <<
-						 desktopUserAgent << "\n";
-					evidence->operator[]("header.user-agent")
+						ResultsHash* results = engine->process(evidence);
+						printResults(results);
+						deviceId_mobile = results->getDeviceId();
+						delete results;
+					};
+					{
+						// Carries out a match for a desktop User-Agent.
+						cout << "\n[---]\n";
+						cout << "Desktop User-Agent: " <<
+							desktopUserAgent << "\n";
+						evidence->operator[]("header.user-agent")
 							= desktopUserAgent;
-					results = engine->process(evidence);
-					cout << "   IsMobile: " <<
-						(*results->getValueAsString("IsMobile")).c_str() << "\n";
-					delete results;
 
-					// Carries out a match for a MediaHub User-Agent.
-					cout << "\nMediaHub User-Agent: " <<
-						 mediaHubUserAgent << "\n";
-					evidence->operator[]("header.user-agent")
+						ResultsHash* results = engine->process(evidence);
+						printResults(results);
+						delete results;
+					};
+					{
+						// Carries out a match for a MediaHub User-Agent.
+						cout << "\n[---]\n";
+						cout << "MediaHub User-Agent: " <<
+							mediaHubUserAgent << "\n";
+						evidence->operator[]("header.user-agent")
 							= mediaHubUserAgent;
-					results = engine->process(evidence);
-					cout << "   IsMobile: " <<
-						(*results->getValueAsString("IsMobile")).c_str() << "\n";
-					delete results;
 
-					// Carries out a match for a platform based on UACH headers.
-					cout << "\nUACH Sec-CH-UA-Platform: " <<
-						uachPlatform << "\n";
-					cout << "UACH Sec-CH-UA-Platform-Version: " <<
-						uachPlatformVersion << "\n";
-					evidence->operator[]("header.Sec-CH-UA-Platform")
-						= uachPlatform;
-					evidence->operator[]("header.Sec-CH-UA-Platform-Version")
-						= uachPlatformVersion;
-					results = engine->process(evidence);
-					cout << "   PlatformName: " <<
-						(*results->getValueAsString("PlatformName")).c_str() 
-						<< "\n";
-					cout << "   PlatformVersion: " <<
-						(*results->getValueAsString("PlatformVersion")).c_str()
-						<< "\n";
-					cout << "   IsMobile: " <<
-						(*results->getValueAsString("IsMobile")).c_str() << "\n";
+						ResultsHash* results = engine->process(evidence);
+						printResults(results);
+						delete results;
+					};
+					std::string deviceId_hintedHub;
+					{
+						// Carries out a match for a platform based on UACH headers.
+						cout << "\n(+)\n";
+						cout << "UACH Sec-CH-UA-Platform: " <<
+							uachPlatform << "\n";
+						cout << "UACH Sec-CH-UA-Platform-Version: " <<
+							uachPlatformVersion << "\n";
+						evidence->operator[]("header.Sec-CH-UA-Platform")
+							= uachPlatform;
+						evidence->operator[]("header.Sec-CH-UA-Platform-Version")
+							= uachPlatformVersion;
 
-					if (0) {
+						ResultsHash* results = engine->process(evidence);
+						printResults(results);
+						deviceId_hintedHub = results->getDeviceId();
+						delete results;
+					};
+					{
 						// Carries out a match for a platform based on device ID.
-						std::string deviceID = results->getDeviceId();
-						cout << "   query.51D_deviceId: " <<
-							deviceID.c_str() << "\n";
-						
-						EvidenceDeviceDetection* evidence2 =
+						cout << "\n(+)\n";
+						cout << "DeviceID: " << deviceId_mobile << " -- Mobile\n";
+
+						evidence->operator[]("query.51D_deviceId")
+							= deviceId_mobile.c_str();
+
+						ResultsHash* results = engine->process(evidence);
+						printResults(results);
+						cout << "  [control platform ID: " << deviceId_hintedHub << " -- MediaHub (hinted, no-deviceId)]\n";
+						delete results;
+					};
+					{
+						// Carries out a match for a mobile User-Agent with hinted MediaHub DeviceID.
+
+						EvidenceDeviceDetection* const evidence2 =
 							new EvidenceDeviceDetection();
+
+						cout << "\n[---]\n";
+						cout << "Mobile User-Agent: " <<
+							mobileUserAgent << "\n";
+						cout << "DeviceID: " << deviceId_hintedHub << " -- MediaHub (hinted)\n";
+
 						evidence2->operator[]("header.user-agent")
 							= mobileUserAgent;
-
-						cout << "\nMobile User-Agent: " <<
-							mobileUserAgent << "\n";
-						ResultsHash* results2 = engine->process(evidence2);
-						cout << "   PlatformName: " <<
-							(*results2->getValueAsString("PlatformName")).c_str()
-							<< "\n";
-						cout << "   PlatformVersion: " <<
-							(*results2->getValueAsString("PlatformVersion")).c_str()
-							<< "\n";
-						cout << "   IsMobile: " <<
-							(*results2->getValueAsString("IsMobile")).c_str() << "\n";
-						delete results2;
-
-						cout << "\nMobile User-Agent: " <<
-							mobileUserAgent << "\n";
-						cout << "query.51D_deviceId: " <<
-							deviceID.c_str() << "\n";
 						evidence2->operator[]("query.51D_deviceId")
-							= deviceID.c_str();
-						results2 = engine->process(evidence2);
-						cout << "   PlatformName: " <<
-							(*results2->getValueAsString("PlatformName")).c_str()
-							<< "\n";
-						cout << "   PlatformVersion: " <<
-							(*results2->getValueAsString("PlatformVersion")).c_str()
-							<< "\n";
-						cout << "   IsMobile: " <<
-							(*results2->getValueAsString("IsMobile")).c_str() << "\n";
-						delete results2;
+							= deviceId_hintedHub.c_str();
+
+						ResultsHash* results = engine->process(evidence2);
+						printResults(results);
+
+						cout << "  [control platform ID: " << deviceId_mobile << " -- Mobile (no-deviceId)]\n";
+						delete results;
 						delete evidence2;
 					};
-					delete results;
 
 					// Free the evidence.
 					delete evidence;
+
+					cout << "\n";
 				}
 			};
 		}

--- a/examples/CPP/Hash/GettingStarted.cpp
+++ b/examples/CPP/Hash/GettingStarted.cpp
@@ -236,6 +236,20 @@ namespace FiftyoneDegrees {
 						delete results;
 					};
 					{
+						// Carries out a match for a platform with invalid device ID.
+						cout << "\n(+)\n";
+						const char* const deviceId_dummy = "123234-2244-1242-2412";
+						cout << "DeviceID: " << deviceId_dummy << " -- Dummy\n";
+
+						evidence->operator[]("query.51D_deviceId")
+							= deviceId_dummy;
+
+						ResultsHash* results = engine->process(evidence);
+						printResults(results);
+						cout << "  [control platform ID: " << deviceId_hintedHub << " -- MediaHub (hinted, no-deviceId)]\n";
+						delete results;
+					};
+					{
 						// Carries out a match for a mobile User-Agent with hinted MediaHub DeviceID.
 
 						EvidenceDeviceDetection* const evidence2 =

--- a/src/EngineDeviceDetection.cpp
+++ b/src/EngineDeviceDetection.cpp
@@ -35,6 +35,7 @@ void EngineDeviceDetection::init(
 	fiftyoneDegreesDataSetDeviceDetection *dataSet) {
 	initHttpHeaderKeys(dataSet->b.uniqueHeaders);
 	initOverrideKeys(dataSet->b.overridable);
+	addKey("query.51D_deviceId");
 }
 
 ResultsDeviceDetection*

--- a/src/hash/graph.c
+++ b/src/hash/graph.c
@@ -224,7 +224,7 @@ fiftyoneDegreesGraphTraceNode* fiftyoneDegreesGraphTraceCreate(
 		length = vsnprintf(NULL, 0, fmt, args);
 		va_end(args);
 		root->rootName = (char*)Malloc((length + 1) * sizeof(char));
-		vsprintf(root->rootName, fmt, args2);
+		vsnprintf(root->rootName, length + 1, fmt, args2);
 		va_end(args2);
 	}
 	else {

--- a/src/hash/hash.c
+++ b/src/hash/hash.c
@@ -2178,35 +2178,11 @@ static bool setResultFromEvidence(
 	return EXCEPTION_OKAY;
 }
 
-static bool isDeviceIdKey(const char* fieldName) {
-	static const char * const reference = "51D_deviceId";
-	if (!fieldName) {
-		return false;
-	}
-	const char *a = fieldName, *b = reference;
-	for (; (*a) && (*b); ++a, ++b) {
-		if (*a == *b) {
-			continue;
-		}
-		const char rawB = *b;
-		if (!(('A' <= rawB && rawB <= 'Z') || ('a' <= rawB && rawB <= 'z'))) {
-			return false; // not a letter + strict equality already failed
-		}
-		const char lowerB = rawB | 0x20; // 'a' - 'A'
-		const char upperB = lowerB - 0x20;
-		if ((*a == lowerB) || (*a == upperB)) {
-			continue;
-		}
-		return false;
-	}
-	return !*a && !*b; // both reached '\0' at the same time
-}
-
 static bool setResultFromDeviceID(
 	void* state,
 	EvidenceKeyValuePair* pair) {
 
-	if (!isDeviceIdKey(pair->field)) {
+	if (StringCompare(pair->field, "51D_deviceId")) {
 		return true; // not a match, skip
 	}
 

--- a/src/hash/hash.c
+++ b/src/hash/hash.c
@@ -2345,6 +2345,19 @@ void fiftyoneDegreesResultsHashFromEvidence(
 				return;
 			}
 
+			if (stateFragment.deviceIdsFound && !fiftyoneDegreesResultsHashGetHasValues(results, 0, exception)) {
+				stateFragment.deviceIdsFound = 0;
+				results->count = 0;
+			}
+
+			if (EXCEPTION_FAILED) {
+				PseudoHeadersRemoveEvidence(
+					evidence->pseudoEvidence,
+					dataSet->config.b.maxMatchedUserAgentLength);
+				evidence->pseudoEvidence = NULL;
+				return;
+			}
+
 			state.state = results;
 		};
 

--- a/src/hash/hash.h
+++ b/src/hash/hash.h
@@ -107,7 +107,8 @@
  */
 #ifndef FIFTYONE_DEGREES_STRING_CACHE_SIZE
 #define FIFTYONE_DEGREES_STRING_CACHE_SIZE 10000
-#endif/**
+#endif
+/**
  * Default value for the string cache loaded size used in the default
  * collection configuration.
  */

--- a/src/hash/hash.h
+++ b/src/hash/hash.h
@@ -107,8 +107,7 @@
  */
 #ifndef FIFTYONE_DEGREES_STRING_CACHE_SIZE
 #define FIFTYONE_DEGREES_STRING_CACHE_SIZE 10000
-#endif
-/**
+#endif/**
  * Default value for the string cache loaded size used in the default
  * collection configuration.
  */
@@ -560,6 +559,12 @@ fiftyoneDegreesHashInitManagerFromMemory(
  * dynamically override values returned from device detection. 'query' prefixes 
  * are also used in preference to 'header' for HTTP header values that are 
  * provided by the application rather than the calling device.
+ * 'query.51D_deviceId' special evidence key has the highest priority and
+ * allows to retrieve the designated device by its 'deviceId'.
+ * 'deviceId' value is obtained as a property in the device detection results
+ * and may be stored and used later to retrieve the same device.
+ * In case provided 'query.51D_deviceId' value is invalid or does not match any
+ * device the other provided evidence will be considered.
  * @param results preallocated results structure to populate containing a
  *                pointer to an initialised resource manager
  * @param evidence to process containing parsed or unparsed values

--- a/test/EngineDeviceDetectionTests.cpp
+++ b/test/EngineDeviceDetectionTests.cpp
@@ -30,6 +30,7 @@
 #define _stricmp strcasecmp
 #endif
 #endif
+#include "../src/common-cxx/fiftyone.h"
 
 using std::ofstream;
 using std::endl;
@@ -306,6 +307,18 @@ void EngineDeviceDetectionTests::verifyWithEmptyUserAgent() {
 	delete results;
 }
 
+void EngineDeviceDetectionTests::verifyHasDeviceIDQueryKey() {
+	string userAgentKey = "query.51D_deviceId";
+	EngineDeviceDetection* engine = (EngineDeviceDetection*)getEngine();
+	const vector<string>* keys = engine->getKeys();
+	for (auto it = keys->begin(), end = keys->end(); it != end; ++it) {
+		if (!StringCompare("query.51D_deviceId", it->c_str())) {
+			return;
+		}
+	}
+	FAIL();
+}
+
 void EngineDeviceDetectionTests::verify() {
 	EngineTests::verify();
 	verifyWithEvidence();
@@ -322,6 +335,7 @@ void EngineDeviceDetectionTests::verify() {
 	verifyWithEvidenceOverrideProfileIDQuery();
 	verifyUserAgentInQuery();
 	verifyValueOverride();
+	verifyHasDeviceIDQueryKey();
 }
 
 void EngineDeviceDetectionTests::userAgentPresent(const char *userAgent) {

--- a/test/EngineDeviceDetectionTests.hpp
+++ b/test/EngineDeviceDetectionTests.hpp
@@ -127,6 +127,7 @@ public:
 	void verifyWithEmptyEvidence();
 	void verifyUserAgentInQuery();
 	void verifyValueOverride();
+	void verifyHasDeviceIDQueryKey();
 	static void multiThreadRandomRunThread(void* state);
 	void multiThreadRandom(uint16_t concurrency);
 	void reloadMemory();

--- a/test/hash/EngineHashTests.cpp
+++ b/test/hash/EngineHashTests.cpp
@@ -705,12 +705,20 @@ public:
 		};
 		{
 			// Carries out a match for a platform with invalid device ID.
-			const char* const deviceId_dummy = "190706-2244-1242-2412";
-			evidence["query.51D_deviceId"] = deviceId_dummy;
+			const char* const deviceId_dummies[] = {
+				"190706-2244-1242-2412",
+				"190706~2244~1242~2412",
+				"aksjfb~ks98-7sd9#83ru",
+				"z",
+				"42",
+			};
+			for (int i = 0, n = sizeof(deviceId_dummies) / sizeof(deviceId_dummies[0]); i < n; ++i) {
+				evidence["query.51D_deviceId"] = deviceId_dummies[i];
 
-			ResultsHash* const results = ((EngineHash*)getEngine())->process(&evidence);
-			EXPECT_STREQ(deviceId_mediaHub.c_str(), results->getDeviceId().c_str());
-			delete results;
+				ResultsHash* const results = ((EngineHash*)getEngine())->process(&evidence);
+				EXPECT_STREQ(deviceId_mediaHub.c_str(), results->getDeviceId().c_str());
+				delete results;
+			}
 		};
 		{
 			// Carries out a match for a mobile User-Agent with hinted MediaHub DeviceID.

--- a/test/hash/EngineHashTests.cpp
+++ b/test/hash/EngineHashTests.cpp
@@ -24,6 +24,7 @@
 #include "../EngineDeviceDetectionTests.hpp"
 #include "../../src/hash/EngineHash.hpp"
 #include <memory>
+#include <functional>
 
 using namespace FiftyoneDegrees::Common;
 using namespace FiftyoneDegrees::DeviceDetection;
@@ -926,23 +927,16 @@ inline static void verifyProcessDeviceIdQuery(EngineHash* const hashEngine) {
 
 	// Collect control device IDs
 
-	std::string deviceId_mobile;
-	{
+	std::function<std::string(const char*)> const deviceIdFromUserAgent = [hashEngine](const char* ua) {
 		EvidenceDeviceDetection evidence;
-		evidence["header.user-agent"] = mobileUserAgent;
+		evidence["header.user-agent"] = ua;
 
 		std::unique_ptr<ResultsHash> const results(hashEngine->process(&evidence));
-		deviceId_mobile = results->getDeviceId();
+		return results->getDeviceId();
 	};
 
-	std::string deviceId_mediaHub;
-	{
-		EvidenceDeviceDetection evidence;
-		evidence["header.user-agent"] = mediaHubUserAgent;
-
-		std::unique_ptr<ResultsHash> const results(hashEngine->process(&evidence));
-		deviceId_mediaHub = results->getDeviceId();
-	};
+	auto const deviceId_mobile = deviceIdFromUserAgent(mobileUserAgent);
+	auto const deviceId_mediaHub = deviceIdFromUserAgent(mediaHubUserAgent);
 
 	std::vector<std::string> const knownIDs = {
 		deviceId_mobile,

--- a/test/hash/EngineHashTests.cpp
+++ b/test/hash/EngineHashTests.cpp
@@ -29,6 +29,8 @@ using namespace FiftyoneDegrees::Common;
 using namespace FiftyoneDegrees::DeviceDetection;
 using namespace FiftyoneDegrees::DeviceDetection::Hash;
 
+inline static void verifyProcessDeviceIdQuery(EngineHash* const hashEngine);
+
 class EngineHashTests : public EngineDeviceDetectionTests {
 public:
 	EngineHashTests(
@@ -675,119 +677,6 @@ public:
 		delete results;
 	}
 
-	inline static void verifyProcessDeviceIdQuery(EngineHash* const hashEngine) {
-
-		// Collect control device IDs
-
-		std::string deviceId_mobile;
-		{
-			EvidenceDeviceDetection evidence;
-			evidence["header.user-agent"] = mobileUserAgent;
-
-			std::unique_ptr<ResultsHash> const results(hashEngine->process(&evidence));
-			deviceId_mobile = results->getDeviceId();
-		};
-
-		std::string deviceId_mediaHub;
-		{
-			EvidenceDeviceDetection evidence;
-			evidence["header.user-agent"] = mediaHubUserAgent;
-
-			std::unique_ptr<ResultsHash> const results(hashEngine->process(&evidence));
-			deviceId_mediaHub = results->getDeviceId();
-		};
-
-		std::vector<std::string> const knownIDs = {
-			deviceId_mobile,
-			deviceId_mediaHub,
-		};
-
-		// Build evidence, check expectations
-
-		{
-			// Use device ID as the only evidence
-			for (auto it = knownIDs.begin(); it != knownIDs.end(); ++it) {
-				std::string const& nextID = *it;
-
-				EvidenceDeviceDetection evidence;
-				evidence["query.51D_deviceId"] = nextID;
-
-				std::unique_ptr<ResultsHash> const results(hashEngine->process(&evidence));
-				EXPECT_STREQ(nextID.c_str(), results->getDeviceId().c_str());
-			};
-		};
-
-		{
-			// Device ID takes precedence over 'normal' evidence, i.e. user-agent
-			{
-				// MediaHub agent + Mobile deviceID
-				EvidenceDeviceDetection evidence;
-				evidence["header.user-agent"] = mediaHubUserAgent;
-				evidence["query.51D_deviceId"] = deviceId_mobile;
-
-				std::unique_ptr<ResultsHash> const results(hashEngine->process(&evidence));
-				EXPECT_STREQ(deviceId_mobile.c_str(), results->getDeviceId().c_str());
-			};
-			{
-				// Mobile agent + MediaHub deviceID
-				// + key case-insensitivity check
-				EvidenceDeviceDetection evidence;
-				evidence["header.user-agent"] = mobileUserAgent;
-				evidence["query.51d_dEVIcEiD"] = deviceId_mediaHub.c_str(); 
-
-				std::unique_ptr<ResultsHash> const results(hashEngine->process(&evidence));
-				EXPECT_STREQ(deviceId_mediaHub.c_str(), results->getDeviceId().c_str());
-			};
-		};
-
-		{
-			// Profile ID overrides are applied over detected device ID.
-			const char* const expectedDeviceId = "12280-17779-17470-18092";
-			const char* const evidenceValue = "12280|17779|17470|18092";
-
-			for (auto it = knownIDs.begin(); it != knownIDs.end(); ++it) {
-				std::string const& nextID = *it;
-
-				EvidenceDeviceDetection evidence;
-				evidence["query.ProfileIds"] = evidenceValue;
-				evidence["query.51D_deviceId"] = nextID;
-
-				std::unique_ptr<ResultsHash> const results(hashEngine->process(&evidence));
-				EXPECT_STREQ(expectedDeviceId, results->getDeviceId().c_str());
-			};
-		};
-
-		{
-			// Invalid device ID.
-			std::vector<std::string> const deviceId_dummies = {
-				"190706-2244-1242-2412",
-				"190706~2244~1242~2412",
-				"aksjfb~ks98-7sd9#83ru",
-				"z",
-				"42",
-			};
-			for (size_t i = 0; i < deviceId_dummies.size(); ++i) {
-				{
-					// no match
-					EvidenceDeviceDetection evidence;
-					evidence["query.51D_deviceId"] = deviceId_dummies[i];
-
-					std::unique_ptr<ResultsHash> const results(hashEngine->process(&evidence));
-					EXPECT_STREQ("0-0-0-0", results->getDeviceId().c_str());
-				};
-				{
-					// fallback
-					EvidenceDeviceDetection evidence;
-					evidence["header.user-agent"] = mediaHubUserAgent;
-					evidence["query.51D_deviceId"] = deviceId_dummies[i];
-
-					std::unique_ptr<ResultsHash> const results(hashEngine->process(&evidence));
-					EXPECT_STREQ(deviceId_mediaHub.c_str(), results->getDeviceId().c_str());
-				};
-			}
-		};
-	}
-
 	void verifyProfileOverrideBad() {
 		EvidenceDeviceDetection evidence;
 		evidence["header.user-agent"] = mobileUserAgent;
@@ -1032,3 +921,116 @@ public:
 };
 
 ENGINE_TESTS(Hash)
+
+inline static void verifyProcessDeviceIdQuery(EngineHash* const hashEngine) {
+
+	// Collect control device IDs
+
+	std::string deviceId_mobile;
+	{
+		EvidenceDeviceDetection evidence;
+		evidence["header.user-agent"] = mobileUserAgent;
+
+		std::unique_ptr<ResultsHash> const results(hashEngine->process(&evidence));
+		deviceId_mobile = results->getDeviceId();
+	};
+
+	std::string deviceId_mediaHub;
+	{
+		EvidenceDeviceDetection evidence;
+		evidence["header.user-agent"] = mediaHubUserAgent;
+
+		std::unique_ptr<ResultsHash> const results(hashEngine->process(&evidence));
+		deviceId_mediaHub = results->getDeviceId();
+	};
+
+	std::vector<std::string> const knownIDs = {
+		deviceId_mobile,
+		deviceId_mediaHub,
+	};
+
+	// Build evidence, check expectations
+
+	{
+		// Use device ID as the only evidence
+		for (auto it = knownIDs.begin(); it != knownIDs.end(); ++it) {
+			std::string const& nextID = *it;
+
+			EvidenceDeviceDetection evidence;
+			evidence["query.51D_deviceId"] = nextID;
+
+			std::unique_ptr<ResultsHash> const results(hashEngine->process(&evidence));
+			EXPECT_STREQ(nextID.c_str(), results->getDeviceId().c_str());
+		};
+	};
+
+	{
+		// Device ID takes precedence over 'normal' evidence, i.e. user-agent
+		{
+			// MediaHub agent + Mobile deviceID
+			EvidenceDeviceDetection evidence;
+			evidence["header.user-agent"] = mediaHubUserAgent;
+			evidence["query.51D_deviceId"] = deviceId_mobile;
+
+			std::unique_ptr<ResultsHash> const results(hashEngine->process(&evidence));
+			EXPECT_STREQ(deviceId_mobile.c_str(), results->getDeviceId().c_str());
+		};
+		{
+			// Mobile agent + MediaHub deviceID
+			// + key case-insensitivity check
+			EvidenceDeviceDetection evidence;
+			evidence["header.user-agent"] = mobileUserAgent;
+			evidence["query.51d_dEVIcEiD"] = deviceId_mediaHub.c_str();
+
+			std::unique_ptr<ResultsHash> const results(hashEngine->process(&evidence));
+			EXPECT_STREQ(deviceId_mediaHub.c_str(), results->getDeviceId().c_str());
+		};
+	};
+
+	{
+		// Profile ID overrides are applied over detected device ID.
+		const char* const expectedDeviceId = "12280-17779-17470-18092";
+		const char* const evidenceValue = "12280|17779|17470|18092";
+
+		for (auto it = knownIDs.begin(); it != knownIDs.end(); ++it) {
+			std::string const& nextID = *it;
+
+			EvidenceDeviceDetection evidence;
+			evidence["query.ProfileIds"] = evidenceValue;
+			evidence["query.51D_deviceId"] = nextID;
+
+			std::unique_ptr<ResultsHash> const results(hashEngine->process(&evidence));
+			EXPECT_STREQ(expectedDeviceId, results->getDeviceId().c_str());
+		};
+	};
+
+	{
+		// Invalid device ID.
+		std::vector<std::string> const deviceId_dummies = {
+			"190706-2244-1242-2412",
+			"190706~2244~1242~2412",
+			"aksjfb~ks98-7sd9#83ru",
+			"z",
+			"42",
+		};
+		for (size_t i = 0; i < deviceId_dummies.size(); ++i) {
+			{
+				// no match
+				EvidenceDeviceDetection evidence;
+				evidence["query.51D_deviceId"] = deviceId_dummies[i];
+
+				std::unique_ptr<ResultsHash> const results(hashEngine->process(&evidence));
+				EXPECT_STREQ("0-0-0-0", results->getDeviceId().c_str());
+			};
+			{
+				// fallback
+				EvidenceDeviceDetection evidence;
+				evidence["header.user-agent"] = mediaHubUserAgent;
+				evidence["query.51D_deviceId"] = deviceId_dummies[i];
+
+				std::unique_ptr<ResultsHash> const results(hashEngine->process(&evidence));
+				EXPECT_STREQ(deviceId_mediaHub.c_str(), results->getDeviceId().c_str());
+			};
+		}
+	};
+}

--- a/test/hash/EngineHashTests.cpp
+++ b/test/hash/EngineHashTests.cpp
@@ -760,7 +760,7 @@ public:
 				"z",
 				"42",
 			};
-			for (int i = 0; i < deviceId_dummies.size(); ++i) {
+			for (size_t i = 0; i < deviceId_dummies.size(); ++i) {
 				{
 					// no match
 					EvidenceDeviceDetection evidence;

--- a/test/hash/EngineHashTests.cpp
+++ b/test/hash/EngineHashTests.cpp
@@ -724,6 +724,17 @@ public:
 			}
 		};
 		{
+			// Carries out a match for a platform with device ID and profile overrides.
+			const char* expectedDeviceId = "12280-17779-17470-18092";
+			const char* evidenceValue = "12280|17779|17470|18092";
+			evidence["query.ProfileIds"] = evidenceValue;
+			evidence["query.51D_deviceId"] = deviceId_mediaHub;
+
+			ResultsHash* const results = ((EngineHash*)getEngine())->process(&evidence);
+			EXPECT_STREQ(expectedDeviceId, results->getDeviceId().c_str());
+			delete results;
+		};
+		{
 			// Carries out a match for a mobile User-Agent with MediaHub DeviceID.
 			EvidenceDeviceDetection evidence2;
 

--- a/test/hash/EngineHashTests.cpp
+++ b/test/hash/EngineHashTests.cpp
@@ -677,6 +677,7 @@ public:
 	void verifyProcessDeviceIdQuery() {
 		EvidenceDeviceDetection evidence;
 
+		// Collect control device IDs
 		std::string deviceId_mobile;
 		{
 			// Carries out a match for a mobile User-Agent.
@@ -695,6 +696,8 @@ public:
 			deviceId_mediaHub = results->getDeviceId();
 			delete results;
 		};
+
+		// Inject IDs and check expectations
 		{
 			// Carries out a match for a platform based on device ID.
 			evidence["query.51D_deviceId"] = deviceId_mobile.c_str();
@@ -721,8 +724,7 @@ public:
 			}
 		};
 		{
-			// Carries out a match for a mobile User-Agent with hinted MediaHub DeviceID.
-
+			// Carries out a match for a mobile User-Agent with MediaHub DeviceID.
 			EvidenceDeviceDetection evidence2;
 
 			evidence2["header.user-agent"] = mobileUserAgent;

--- a/test/hash/EngineHashTests.cpp
+++ b/test/hash/EngineHashTests.cpp
@@ -205,7 +205,7 @@ public:
 		verifyProfileOverrideNoUserAgent();
 		verifyWithLongPseudoHeader();
 		verifyProcessDeviceId();
-		verifyProcessDeviceIdQuery();
+		verifyProcessDeviceIdQuery((EngineHash*)getEngine());
 		verifyProfileOverridePartial();
 		verifyProfileOverrideZero();
 		verifyNoMatchedNodes();
@@ -675,8 +675,7 @@ public:
 		delete results;
 	}
 
-	void verifyProcessDeviceIdQuery() {
-		auto const hashEngine = (EngineHash*)getEngine();
+	inline static void verifyProcessDeviceIdQuery(EngineHash* const hashEngine) {
 
 		// Collect control device IDs
 

--- a/test/hash/EngineHashTests.cpp
+++ b/test/hash/EngineHashTests.cpp
@@ -24,7 +24,6 @@
 #include "../EngineDeviceDetectionTests.hpp"
 #include "../../src/hash/EngineHash.hpp"
 #include <memory>
-#include <functional>
 
 using namespace FiftyoneDegrees::Common;
 using namespace FiftyoneDegrees::DeviceDetection;
@@ -681,15 +680,23 @@ public:
 
 		// Collect control device IDs
 
-		std::function<std::string(const char *)> const deviceIdFromUserAgent = [hashEngine](const char* ua) {
+		std::string deviceId_mobile;
+		{
 			EvidenceDeviceDetection evidence;
-			evidence["header.user-agent"] = ua;
+			evidence["header.user-agent"] = mobileUserAgent;
 
 			std::unique_ptr<ResultsHash> const results(hashEngine->process(&evidence));
-			return results->getDeviceId();
+			deviceId_mobile = results->getDeviceId();
 		};
-		auto const deviceId_mobile = deviceIdFromUserAgent(mobileUserAgent);
-		auto const deviceId_mediaHub = deviceIdFromUserAgent(mediaHubUserAgent);
+
+		std::string deviceId_mediaHub;
+		{
+			EvidenceDeviceDetection evidence;
+			evidence["header.user-agent"] = mediaHubUserAgent;
+
+			std::unique_ptr<ResultsHash> const results(hashEngine->process(&evidence));
+			deviceId_mediaHub = results->getDeviceId();
+		};
 
 		std::vector<std::string> const knownIDs = {
 			deviceId_mobile,


### PR DESCRIPTION
### Changes
- Use `ResultsHashFromDeviceId` from `ResultsHashFromEvidence` if `query.51D_deviceId` is present.
- Discard partially detected profile (`NULL_PROFILE_OFFSET`).
- Expand `GettingStarted.c`/`.cpp` examples.
- Add `query.51D_deviceId` to `getKeys()`.
- Update README.
- Update unit tests.

### Why
- https://github.com/51Degrees/device-detection-cxx/issues/72