### PR TITLE
Address problem with corrupt evidence data.

### DIFF
--- a/examples/C/Hash/OfflineProcessing.c
+++ b/examples/C/Hash/OfflineProcessing.c
@@ -202,12 +202,14 @@ static void process(KeyValuePair *pairs, uint16_t size, void *state) {
 	for (uint32_t i = 0; i < size; i++) {
 		// Get prefix
 		EvidencePrefixMap *prefixMap = EvidenceMapPrefix(pairs[i].key);
-		// Add the evidence as string
-		EvidenceAddString(
-			evidenceArray,
-			prefixMap->prefixEnum,
-			pairs[i].key + prefixMap->prefixLength,
-			pairs[i].value);
+		if (prefixMap) {
+			// Add the evidence as string
+			EvidenceAddString(
+				evidenceArray,
+				prefixMap->prefixEnum,
+				pairs[i].key + prefixMap->prefixLength,
+				pairs[i].value);
+		}
 	}
 	analyse(
 		offline->results,

--- a/examples/C/Hash/Performance.c
+++ b/examples/C/Hash/Performance.c
@@ -241,12 +241,14 @@ void runPerformanceThread(void* state) {
 			EvidencePrefixMap* prefixMap = EvidenceMapPrefix(
 				(&thisState->mainState->evidence[i]->pairs)[j].key);
 
-			// Add the evidence as string
-			EvidenceAddString(
-				evidence,
-				prefixMap->prefixEnum,
-				(&thisState->mainState->evidence[i]->pairs)[j].key + prefixMap->prefixLength,
-				(&thisState->mainState->evidence[i]->pairs)[j].value);
+			// Add the evidence as string if valid.
+			if (prefixMap != NULL) {
+				EvidenceAddString(
+					evidence,
+					prefixMap->prefixEnum,
+					(&thisState->mainState->evidence[i]->pairs)[j].key + prefixMap->prefixLength,
+					(&thisState->mainState->evidence[i]->pairs)[j].value);
+			}
 		}
 		ResultsHashFromEvidence(results, evidence, exception);
 		EXCEPTION_THROW;
@@ -515,10 +517,13 @@ void fiftyoneDegreesHashPerformance(
 		Malloc(sizeof(EvidencePrefixMap*) * state.evidenceCount);
 	if (state.evidenceCount < state.iterationsPerThread) {
 		fprintf(state.output, 
-			"Not enough evidence for the requested number of iterations. "
-			"Running %d iterations per thread\n", state.evidenceCount);
+			"Not enough evidence for %d iterations.\n",
+			state.iterationsPerThread);
 		state.iterationsPerThread = state.evidenceCount;
 	}
+	fprintf(
+		state.output,
+		"Reading %d evidence records into memory.\n", state.evidenceCount);
 	state.evidenceCount = 0;
 	YamlFileIterate(
 		evidenceFilePath,

--- a/test/hash/ExampleHashPerformanceTests.cpp
+++ b/test/hash/ExampleHashPerformanceTests.cpp
@@ -31,7 +31,7 @@ public:
 
 		fiftyoneDegreesHashPerformance(
 			dataFilePath.c_str(),
-			userAgentFilePath.c_str(),
+			evidenceFilePath.c_str(),
 			4,
 			10000,
 			stdout,


### PR DESCRIPTION
If the evidence contains values that don't relate to valid prefixes then the example will fail. Now checks for invalid data and does not consider it.

Modified the message concerning the number of evidence records being used to be clearer.

Includes the updated common repository that addresses issues reading yaml data.