### PR TITLE
Update tests after YAML Reader patch.

### DIFF
--- a/examples/C/Hash/OfflineProcessing.c
+++ b/examples/C/Hash/OfflineProcessing.c
@@ -202,12 +202,14 @@ static void process(KeyValuePair *pairs, uint16_t size, void *state) {
 	for (uint32_t i = 0; i < size; i++) {
 		// Get prefix
 		EvidencePrefixMap *prefixMap = EvidenceMapPrefix(pairs[i].key);
-		// Add the evidence as string
-		EvidenceAddString(
-			evidenceArray,
-			prefixMap->prefixEnum,
-			pairs[i].key + prefixMap->prefixLength,
-			pairs[i].value);
+		if (prefixMap) {
+			// Add the evidence as string
+			EvidenceAddString(
+				evidenceArray,
+				prefixMap->prefixEnum,
+				pairs[i].key + prefixMap->prefixLength,
+				pairs[i].value);
+		}
 	}
 	analyse(
 		offline->results,

--- a/test/hash/ExampleHashPerformanceTests.cpp
+++ b/test/hash/ExampleHashPerformanceTests.cpp
@@ -31,7 +31,7 @@ public:
 
 		fiftyoneDegreesHashPerformance(
 			dataFilePath.c_str(),
-			userAgentFilePath.c_str(),
+			evidenceFilePath.c_str(),
 			4,
 			10000,
 			stdout,


### PR DESCRIPTION
### Changes
- Apply the nullness check of `prefixMap` from `Performance.c` to `OfflineProcessing.c`.
- Use YAML evidence file for performance testing

### Why
- YamlFileIterator is not handling CSV file properly due to colon appearing in URLs:
```
Mozilla/5.0 (Windows NT 6.1; Win64; x64; +http://www.komodia.com/newwiki/index.php/URL_server_crawler) KomodiaBot/1.0
```
^ line 10 of https://github.com/51Degrees/device-detection-data/blob/main/20000%20User%20Agents.csv
