### PR TITLE
FEAT: Prevent C code returning GHEV JavaScript when the evidence already contains the required values.

### DIFF
--- a/VisualStudio/FiftyOne.DeviceDetection.C/FiftyOne.DeviceDetection.C.vcxproj
+++ b/VisualStudio/FiftyOne.DeviceDetection.C/FiftyOne.DeviceDetection.C.vcxproj
@@ -13,11 +13,13 @@
     <ClInclude Include="..\..\src\fiftyone.h" />
     <ClInclude Include="..\..\src\results-dd.h" />
     <ClInclude Include="..\..\src\transform.h" />
+    <ClInclude Include="..\..\src\gethighentropyvalues.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\dataset-dd.c" />
     <ClCompile Include="..\..\src\results-dd.c" />
     <ClCompile Include="..\..\src\transform.c" />
+    <ClCompile Include="..\..\src\gethighentropyvalues.c" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\common-cxx\VisualStudio\FiftyOne.Common.C\FiftyOne.Common.C.vcxproj">

--- a/VisualStudio/FiftyOne.DeviceDetection.Hash.Tests/FiftyOne.DeviceDetection.Hash.Tests.vcxproj
+++ b/VisualStudio/FiftyOne.DeviceDetection.Hash.Tests/FiftyOne.DeviceDetection.Hash.Tests.vcxproj
@@ -18,6 +18,7 @@
     <ClInclude Include="..\..\test\Constants.hpp" />
     <ClInclude Include="..\..\test\EngineDeviceDetectionTests.hpp" />
     <ClInclude Include="..\..\test\ExampleDeviceDetectionTests.hpp" />
+    <ClInclude Include="..\..\test\hash\SimpleEngineTestBase.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\common-cxx\tests\Base.cpp" />
@@ -51,6 +52,7 @@
     <ClCompile Include="..\..\test\hash\TransformTests.cpp" />
     <ClCompile Include="..\..\test\hash\ResultsHashSerializerTests.cpp" />
     <ClCompile Include="..\..\test\hash\SuppressSnippetTests.cpp" />
+    <ClCompile Include="..\..\test\hash\SimpleEngineTestBase.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/VisualStudio/FiftyOne.DeviceDetection.Hash.Tests/FiftyOne.DeviceDetection.Hash.Tests.vcxproj
+++ b/VisualStudio/FiftyOne.DeviceDetection.Hash.Tests/FiftyOne.DeviceDetection.Hash.Tests.vcxproj
@@ -50,6 +50,7 @@
     <ClCompile Include="..\..\test\hash\HashMemLeakReloadFromFileTests.cpp" />
     <ClCompile Include="..\..\test\hash\TransformTests.cpp" />
     <ClCompile Include="..\..\test\hash\ResultsHashSerializerTests.cpp" />
+    <ClCompile Include="..\..\test\hash\SuppressSnippetTests.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/examples/C/Hash/GettingStarted.c
+++ b/examples/C/Hash/GettingStarted.c
@@ -380,7 +380,9 @@ void fiftyoneDegreesHashGettingStarted(
 	// returned when all the required evidence is already present.
 	ResultsHash *results = ResultsHashCreate(&manager, 1);
 
-	for (int i = 0; i < sizeof(evidenceValues)/sizeof(evidence*); i++) {
+	for (int i = 0;
+		i < (int)sizeof(evidenceValues)/(int)sizeof(evidence*);
+		i++) {
 		// Create an evidence collection and add the evidence.
 		evidence* evs = evidenceValues[i];
 		EvidenceKeyValuePairArray* evidenceArray = EvidenceCreate(evs->count);

--- a/examples/C/Hash/OfflineProcessing.c
+++ b/examples/C/Hash/OfflineProcessing.c
@@ -160,7 +160,9 @@ static void analyse(
 		EvidenceKeyValuePair e = evidence->items[i];
 		fprintf(outputFile,
 			"%s%s: %s\n",
-			EvidencePrefixString(e.prefix), e.field, (char *)e.originalValue);
+			EvidencePrefixString(e.prefix), 
+			e.item.key, 
+			e.item.value);
 	}
 
 	EXCEPTION_CREATE

--- a/src/EvidenceDeviceDetection.hpp
+++ b/src/EvidenceDeviceDetection.hpp
@@ -33,6 +33,10 @@ namespace FiftyoneDegrees {
 		 * Device detection specific evidence class containing evidence to be
 		 * processed by a device detection engine.
 		 * This wraps a dynamically generated C evidence structure.
+         *
+         * Note: additional capacity hint must be passed when
+         * evidence may be expanded into additional kv pairs - f.e.
+         *  51d_gethighenropyvalues or 51d_sua is present.
 		 *
 		 * The class extends the EvidenceBase class to implement the
 		 * EvidenceBase::isRelevant method to return for device detection
@@ -71,7 +75,8 @@ namespace FiftyoneDegrees {
 			/**
 			 * @copydoc Common::EvidenceBase::EvidenceBase
 			 */
-			EvidenceDeviceDetection() : EvidenceBase() {}
+			EvidenceDeviceDetection(size_t additionalCapacity=0) : 
+            EvidenceBase(additionalCapacity) {}
 
 			/**
 			 * @}

--- a/src/EvidenceDeviceDetection.hpp
+++ b/src/EvidenceDeviceDetection.hpp
@@ -33,10 +33,6 @@ namespace FiftyoneDegrees {
 		 * Device detection specific evidence class containing evidence to be
 		 * processed by a device detection engine.
 		 * This wraps a dynamically generated C evidence structure.
-         *
-         * Note: additional capacity hint must be passed when
-         * evidence may be expanded into additional kv pairs - f.e.
-         *  51d_gethighenropyvalues or 51d_sua is present.
 		 *
 		 * The class extends the EvidenceBase class to implement the
 		 * EvidenceBase::isRelevant method to return for device detection
@@ -72,11 +68,10 @@ namespace FiftyoneDegrees {
 			 * @{
 			 */
 
-			/**
-			 * @copydoc Common::EvidenceBase::EvidenceBase
-			 */
-			EvidenceDeviceDetection(size_t additionalCapacity=0) : 
-            EvidenceBase(additionalCapacity) {}
+			 /**
+			  * @copydoc Common::EvidenceBase::EvidenceBase
+			  */
+			EvidenceDeviceDetection() : EvidenceBase() {}
 
 			/**
 			 * @}

--- a/src/EvidenceDeviceDetection.i
+++ b/src/EvidenceDeviceDetection.i
@@ -28,5 +28,5 @@
 
 class EvidenceDeviceDetection : public EvidenceBase {
 public:
-	EvidenceDeviceDetection();
+	EvidenceDeviceDetection(size_t additionalCapacity=0);
 };

--- a/src/dataset-dd.c
+++ b/src/dataset-dd.c
@@ -75,6 +75,10 @@ fiftyoneDegreesDataSetDeviceDetectionInitPropertiesAndHeaders(
 		state,
 		overridesFilter);
 
+	// The ghevHeaders member is initialised in 
+	// fiftyoneDegreesGhevDeviceDetectionInit if required.
+	dataSet->ghevHeaders = NULL;
+
 	return status;
 }
 
@@ -85,6 +89,10 @@ void fiftyoneDegreesDataSetDeviceDetectionRelease(
 
 void fiftyoneDegreesDataSetDeviceDetectionFree(
 	fiftyoneDegreesDataSetDeviceDetection *dataSet) {
+	if (dataSet->ghevHeaders != NULL) {
+		Free(dataSet->ghevHeaders);
+		dataSet->ghevHeaders = NULL;
+	}
 	DataSetFree(&dataSet->b);
 }
 
@@ -98,4 +106,5 @@ void fiftyoneDegreesDataSetDeviceDetectionReset(
 	fiftyoneDegreesDataSetDeviceDetection *dataSet) {
 	DataSetReset(&dataSet->b);
 	dataSet->uniqueUserAgentHeaderIndex = 0;
+	dataSet->ghevHeaders = NULL;
 }

--- a/src/dataset-dd.h
+++ b/src/dataset-dd.h
@@ -53,6 +53,13 @@ typedef struct fiftyone_degrees_dataset_device_detection_t {
 	fiftyoneDegreesDataSetBase b; /**< Base structure members */
 	uint32_t uniqueUserAgentHeaderIndex; /**< The unique HTTP header for the 
 										 field name "User-Agent" */
+	fiftyoneDegreesHeaderPtrArray *ghevHeaders; /**< Array of get high entropy 
+											    values headers that must all be 
+											    present to prevent the 
+											    gethighentropyvalues javascript 
+											    from being returned */
+	int ghevRequiredPropertyIndex; /**< Required property index for 
+						   		   JavascriptGetHighEntropyValues */
 } fiftyoneDegreesDataSetDeviceDetection;
 
 /**

--- a/src/fiftyone.h
+++ b/src/fiftyone.h
@@ -46,6 +46,7 @@
 #include "config-dd.h"
 #include "results-dd.h"
 #include "transform.h"
+#include "gethighentropyvalues.h"
 
 MAP_TYPE(ConfigDeviceDetection)
 MAP_TYPE(ResultsDeviceDetection)
@@ -75,6 +76,10 @@ MAP_TYPE(TransformIterateResult)
 #define TransformIterateGhevFromBase64 fiftyoneDegreesTransformIterateGhevFromBase64 /**< Synonym for fiftyoneDegreesTransformIterateGhevFromBase64 */
 #define TransformIterateGhevFromJson fiftyoneDegreesTransformIterateGhevFromJson /**< Synonym for fiftyoneDegreesTransformIterateGhevFromJson */
 #define TransformCallback fiftyoneDegreesTransformCallback /**< Synonym for fiftyoneDegreesTransformCallback */
+
+#define GhevDeviceDetectionInit fiftyoneDegreesGhevDeviceDetectionInit /**< Synonym for fiftyoneDegreesGhevDeviceDetectionInit */
+#define GhevDeviceDetectionAllPresent fiftyoneDegreesGhevDeviceDetectionAllPresent /**< Synonym for fiftyoneDegreesGhevDeviceDetectionAllPresent */
+#define GhevDeviceDetectionOverride fiftyoneDegreesGhevDeviceDetectionOverride /**< Synonym for fiftyoneDegreesGhevDeviceDetectionOverride */
 
 /**
  * @}

--- a/src/gethighentropyvalues.c
+++ b/src/gethighentropyvalues.c
@@ -88,6 +88,9 @@ static bool countHeadersCallback(
 	fiftyoneDegreesHeader* header,
 	const char* value,
 	size_t length) {
+    (void)header;
+    (void)value;
+    (void)length; // to suppress C4100 warning
     (*(int*)state)++;
     return true;
 }
@@ -99,7 +102,6 @@ static bool isAcceptCh(
     Exception *exception) {
     Item stringItem;
     String* name;
-    char* startChar;
     bool result = false;
 
     // Get the name of the property from the strings collection.
@@ -305,7 +307,8 @@ bool fiftyoneDegreesGhevDeviceDetectionAllPresent(
     fiftyoneDegreesDataSetDeviceDetection *dataSet,
     fiftyoneDegreesEvidenceKeyValuePairArray *evidence,
     fiftyoneDegreesException *exception) {
-    int counter = 0;
+    (void)exception; // to suppress C4100 warning
+    unsigned int counter = 0;
 
     // If the init method was not called or couldn't initialise the required
     // data structure then return false.
@@ -333,6 +336,7 @@ void fiftyoneDegreesGhevDeviceDetectionOverride(
     fiftyoneDegreesDataSetDeviceDetection *dataSet,
     fiftyoneDegreesResultsDeviceDetection *results,
 	fiftyoneDegreesException *exception) {
+    (void)exception; // to suppress C4100 warning
     OverridesAdd(
         results->overrides,
         dataSet->ghevRequiredPropertyIndex,

--- a/src/gethighentropyvalues.c
+++ b/src/gethighentropyvalues.c
@@ -55,7 +55,7 @@ static bool isHeaderNew(
     HeaderPtr ptr;
     for(uint32_t i = 0; i < dataSet->ghevHeaders->count; i++) {
         ptr = dataSet->ghevHeaders->items[i];
-        if (ptr->length == length &&
+        if (ptr->nameLength == length &&
             StringCompareLength(name, ptr->name, length) == 0) {
             return false;
         }
@@ -85,12 +85,8 @@ static void addHeaderCallback(
 // Returns true to keep iterating over the headers.
 static bool countHeadersCallback(
 	void* state,
-	fiftyoneDegreesHeader* header,
-	const char* value,
-	size_t length) {
-    (void)header;
-    (void)value;
-    (void)length; // to suppress C4100 warning
+	EvidenceKeyValuePair *pair) {
+    (void)pair; // to suppress C4100 warning
     (*(int*)state)++;
     return true;
 }

--- a/src/gethighentropyvalues.c
+++ b/src/gethighentropyvalues.c
@@ -1,0 +1,340 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2023 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+#include "gethighentropyvalues.h"
+#include "fiftyone.h"
+
+// The property name of the GHEV javascript. This property value can be 
+// overridden with no value if there is no need for it to be returned.
+#define TARGET_PROPERTY_NAME "JavascriptGetHighEntropyValues"
+
+// Properties that end in this string contain values that are HTTP headers that
+// need to be present for UACH device detection.
+#define ACCEPT_CH "Accept-CH"
+
+// Number of characters in ACCEPT_CH.
+#define ACCEPT_CH_LENGTH 9
+
+/**
+ * Method used to iterate over values associated with properties ending 
+ * ACCEPT_CH.
+ * @param dataSet to add GHEV headers to
+ * @param name of the property as a string
+ * @param length the length of name excluding a terminator
+ */
+typedef void(*valueIterateMethod)(
+    DataSetDeviceDetection *dataSet,
+    const char *name,
+    size_t length);
+
+// Returns true if the header name does not already exist in the 
+// dataSet->ghevHeaders.
+static bool isHeaderNew(
+    DataSetDeviceDetection *dataSet, 
+    const char *name, 
+    size_t length) {
+    HeaderPtr ptr;
+    for(uint32_t i = 0; i < dataSet->ghevHeaders->count; i++) {
+        ptr = dataSet->ghevHeaders->items[i];
+        if (ptr->length == length &&
+            StringCompareLength(name, ptr->name, length) == 0) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// Gets the header index from the dataset's uniqueHeaders collection and if
+// present adds a pointer to the header into the ghevHeaders array.
+static void addHeaderCallback(
+    DataSetDeviceDetection *dataSet, 
+    const char *name, 
+    size_t length) {
+    if (isHeaderNew(dataSet, name, length)) {
+        int index = HeaderGetIndex(
+            dataSet->b.uniqueHeaders, 
+            name,
+            length);
+        if (index >= 0) {
+            dataSet->ghevHeaders->items[dataSet->ghevHeaders->count++] = 
+                &dataSet->b.uniqueHeaders->items[index];
+        }
+    }
+}
+
+// State is an integer pointer and is used to count the number of headers found.
+// Returns true to keep iterating over the headers.
+static bool countHeadersCallback(
+	void* state,
+	fiftyoneDegreesHeader* header,
+	const char* value,
+	size_t length) {
+    (*(int*)state)++;
+    return true;
+}
+
+// Returns true if the property name ends with ACCEPT_CH, otherwise false.
+static bool isAcceptCh(
+    fiftyoneDegreesCollection *strings,
+    Property *property,
+    Exception *exception) {
+    Item stringItem;
+    String* name;
+    char* startChar;
+    bool result = false;
+
+    // Get the name of the property from the strings collection.
+    DataReset(&stringItem.data);
+    name = fiftyoneDegreesStringGet(
+        strings,
+        property->nameOffset,
+        &stringItem,
+        exception);
+    if (name != NULL && EXCEPTION_OKAY) {
+
+        // Set the result based on whether the property name ends with 
+        // ACCEPT_CH. Note that the size of the string includes the null 
+        // terminator which is why another -1 is needed.
+        result = name->size > ACCEPT_CH_LENGTH &&
+            StringCompareLength(
+                &name->value + (name->size - ACCEPT_CH_LENGTH - 1), 
+                ACCEPT_CH, 
+                ACCEPT_CH_LENGTH) == 0;
+
+        // Release the string.
+        COLLECTION_RELEASE(strings, &stringItem);
+    }
+
+    return result;
+}
+
+// Some values might include separator characters to split up values. This 
+// method checks for these situations and returns either the whole value if
+// there are no separators, or each segment if there are. When used to count the
+// headers returned there will be a null callback so this is checked for. 
+static int iterateValueSeparators(
+    DataSetDeviceDetection *dataSet,
+    valueIterateMethod callback,
+    char *value, 
+    char separator) {
+    int i = 0;
+    int count = 0;
+
+    // Find any separators and pass to the callback.
+    while (value[i] != '\0') {
+        if (value[i] == separator) {
+            if (callback != NULL) {
+                callback(dataSet, value, i);
+            }
+            count++;
+            value = &value[i + 1];
+            i = 0;
+        } else {
+            i++;
+        }
+    }
+
+    // Return the last segment or the whole value if no segments.
+    if (callback != NULL) {
+        callback(dataSet, value, i);
+    }
+    count++;
+
+    return count;
+}
+
+// Iterate all the value strings for the property calling the callback for each.
+// The callback will be null when a count of the values is required for the 
+// purposes of setting the size of the array used in the second pass.
+static int iterateValues(
+    DataSetDeviceDetection *dataSet,
+    fiftyoneDegreesCollection *values,
+    fiftyoneDegreesCollection *strings,
+    Property *property,
+	valueIterateMethod callback,
+	Exception *exception) {
+    Item valueItem;
+    Item stringItem;
+    String *name;
+    Value *value;
+    int count = 0;
+    DataReset(&valueItem.data);
+    DataReset(&stringItem.data);
+    for(uint32_t i = property->firstValueIndex; 
+        i <= property->lastValueIndex && EXCEPTION_OKAY; 
+        i++) {
+        value = ValueGet(values, i, &valueItem, exception);
+        if (value != NULL && EXCEPTION_OKAY) {
+            name = StringGet(
+                strings,
+                value->nameOffset,
+                &stringItem,
+                exception);
+            if (name != NULL && EXCEPTION_OKAY) {
+
+                count += iterateValueSeparators(
+                    dataSet, 
+                    callback, 
+                    &name->value, 
+                    ',');
+
+                COLLECTION_RELEASE(strings, &stringItem);
+            }
+            COLLECTION_RELEASE(values, &valueItem);
+        }
+    }
+    return count;
+}
+
+static int iterateProperties(
+    DataSetDeviceDetection *dataSet,
+	fiftyoneDegreesCollection *properties,
+    fiftyoneDegreesCollection *values,
+    fiftyoneDegreesCollection *strings,
+	valueIterateMethod callback,
+	Exception *exception) {
+    Item item;
+    uint32_t propertiesCount = CollectionGetCount(properties);
+    int count = 0;
+	DataReset(&item.data);
+
+    for(uint32_t i = 0; i < propertiesCount && EXCEPTION_OKAY; i++) {
+        Property* property = (Property*)properties->get(
+            properties, 
+            i, 
+            &item,
+            exception);
+        if (property != NULL && EXCEPTION_OKAY) {
+
+            // If this is any ACCEPT_CH property then iterate the values
+            // increasing the count of the values available.
+            if (isAcceptCh(strings, property, exception) && EXCEPTION_OKAY) {
+                count += iterateValues(
+                    dataSet, 
+                    values, 
+                    strings, 
+                    property, 
+                    callback, 
+                    exception);
+            }
+
+            // Release the property.
+            COLLECTION_RELEASE(properties, &item);
+        }
+    }
+
+    return count;
+}
+
+void fiftyoneDegreesGhevDeviceDetectionInit(
+	fiftyoneDegreesDataSetDeviceDetection *dataSet,
+    fiftyoneDegreesCollection *properties,
+    fiftyoneDegreesCollection *values,
+    fiftyoneDegreesCollection *strings,
+    fiftyoneDegreesException *exception) {
+    int capacity, count;
+
+    // If the GHEV property is not an available property then there is no need
+    // for this functionality and the data structure can be set to null.
+    dataSet->ghevRequiredPropertyIndex = PropertiesGetRequiredPropertyIndexFromName(
+        dataSet->b.available,
+        TARGET_PROPERTY_NAME);
+    if (dataSet->ghevRequiredPropertyIndex < 0) {
+        return;
+    }
+
+    // Get the number of headers that need to be included in the 
+    // dataSet->ghevHeaders array.
+    capacity = iterateProperties(
+        dataSet, 
+        properties, 
+        values, 
+        strings,
+        NULL,
+        exception);
+
+    // If no headers are identified then set the array to empty.
+    if (capacity == 0) {
+        return;
+    }
+
+    // Create the array of header pointers with sufficient capacity for to store
+    // all the GHEV headers.
+	FIFTYONE_DEGREES_ARRAY_CREATE(
+		fiftyoneDegreesHeaderPtr,
+		dataSet->ghevHeaders,
+		capacity);
+    if (dataSet->ghevHeaders == NULL) {
+		EXCEPTION_SET(INSUFFICIENT_MEMORY);
+		return;
+	}
+
+    // Add the headers in the second iteration.
+    count = iterateProperties(
+        dataSet, 
+        properties,
+        values, 
+        strings,
+        addHeaderCallback,
+        exception);
+
+    // Check the number of headers added is the same as the capacity.
+    assert(count == capacity);
+}
+
+bool fiftyoneDegreesGhevDeviceDetectionAllPresent(
+    fiftyoneDegreesDataSetDeviceDetection *dataSet,
+    fiftyoneDegreesEvidenceKeyValuePairArray *evidence,
+    fiftyoneDegreesException *exception) {
+    int counter = 0;
+
+    // If the init method was not called or couldn't initialise the required
+    // data structure then return false.
+    if (dataSet->ghevHeaders == NULL) {
+        return false;
+    }
+
+    // Iterate all the available headers in evidence that also present in the
+    // dataSet->ghevHeaders headers.
+    EvidenceIterateForHeaders(
+        evidence, 
+        INT_MAX,
+        dataSet->ghevHeaders, 
+        NULL, 
+        0, 
+        &counter, 
+        countHeadersCallback);
+    
+    // If the counter is the same as all the required headers then they are all
+    // present in the evidence.
+    return counter == dataSet->ghevHeaders->count;
+}
+
+void fiftyoneDegreesGhevDeviceDetectionOverride(
+    fiftyoneDegreesDataSetDeviceDetection *dataSet,
+    fiftyoneDegreesResultsDeviceDetection *results,
+	fiftyoneDegreesException *exception) {
+    OverridesAdd(
+        results->overrides,
+        dataSet->ghevRequiredPropertyIndex,
+        "");
+}

--- a/src/gethighentropyvalues.h
+++ b/src/gethighentropyvalues.h
@@ -1,0 +1,74 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2023 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+#ifndef FIFTYONE_DEGREES_GHEV_DEVICE_DETECTION_H_INCLUDED
+#define FIFTYONE_DEGREES_GHEV_DEVICE_DETECTION_H_INCLUDED
+
+#include "dataset-dd.h"
+#include "results-dd.h"
+
+/**
+ * Initialise the device detection data set with the pointers to the headers
+ * that are needed for gethighentropyvalues. These header must be present in the
+ * evidence for the gethighentropyvalues javascript to not be returned.
+ * @param dataSet pointer to the data set with the relevant properties and 
+ * headers enabled.
+ * @param properties collection
+ * @param values collection
+ * @param strings collection
+ * @param exception pointer to an exception data structure to be used if an
+ * exception occurs. See exceptions.h.
+ */
+void fiftyoneDegreesGhevDeviceDetectionInit(
+    fiftyoneDegreesDataSetDeviceDetection *dataSet,
+    fiftyoneDegreesCollection *properties,
+    fiftyoneDegreesCollection *values,
+    fiftyoneDegreesCollection *strings,
+    fiftyoneDegreesException *exception);
+
+/**
+ * True if all the headers are present and gethighentropyvalues javascript is 
+ * not required.
+ * @param dataSet pointer to the data set with an initialised ghevHeaders array.
+ * @param evidence fully initialised with all available headers.
+ * @param exception pointer to an exception data structure to be used if an
+ * exception occurs. See exceptions.h.
+ */
+bool fiftyoneDegreesGhevDeviceDetectionAllPresent(
+    fiftyoneDegreesDataSetDeviceDetection *dataSet,
+    fiftyoneDegreesEvidenceKeyValuePairArray *evidence,
+    fiftyoneDegreesException *exception);
+
+/**
+ * True if all the headers are present and gethighentropyvalues javascript is 
+ * not required.
+ * @param dataSet pointer to the data set with an initialised ghevHeaders array.
+ * @param results for the override to be applied to.
+ * @param exception pointer to an exception data structure to be used if an
+ * exception occurs. See exceptions.h.
+ */
+void fiftyoneDegreesGhevDeviceDetectionOverride(
+    fiftyoneDegreesDataSetDeviceDetection *dataSet,
+    fiftyoneDegreesResultsDeviceDetection *results,
+	fiftyoneDegreesException *exception);
+
+#endif

--- a/src/hash/EngineHash.cpp
+++ b/src/hash/EngineHash.cpp
@@ -272,7 +272,10 @@ Common::ResultsBase* EngineHash::processBase(
 		results, 
 		evidence == nullptr ? nullptr : evidence->get(),
 		exception);
-	EXCEPTION_THROW;
+	if (EXCEPTION_FAILED) {
+		ResultsHashFree(results);
+		EXCEPTION_THROW;
+	}
 	return new ResultsHash(results, manager);
 }
 

--- a/src/hash/hash.c
+++ b/src/hash/hash.c
@@ -2796,11 +2796,10 @@ static void resultsHashFromEvidence_extractOverrides(
 		if (overridingPropertyIndex >= 0) {
 			// Get the property index so that the type of the property that 
 			// performs the override can be checked before it is removed
-			// from  the result.
-			const int propertyIndex = 
-				PropertiesGetPropertyIndexFromRequiredIndex(
-					state->dataSet->b.b.available,
-					overridingPropertyIndex);
+			// from the result.
+			const int propertyIndex = PropertiesGetPropertyIndexFromRequiredIndex(
+				state->dataSet->b.b.available,
+				overridingPropertyIndex);
 			if (PropertyGetValueType(
 				state->dataSet->properties,
 				propertyIndex,
@@ -3636,7 +3635,7 @@ bool fiftyoneDegreesResultsHashGetHasValues(
 		// The property index is not valid.
 		return false;
 	}
-	if (fiftyoneDegreesOverrideHasValueForRequiredPropertyIndex(
+	if (OverrideHasValueForRequiredPropertyIndex(
 		results->b.overrides,
 		requiredPropertyIndex)) {
 		// There is an override value for the property.

--- a/src/hash/hash.c
+++ b/src/hash/hash.c
@@ -2631,18 +2631,19 @@ static bool setGetHighEntropyValuesHeader(
 	detectionComponentState* state,
 	EvidenceKeyValuePair* pair) {
 	EXCEPTION_CREATE
-	TransformIterateResult result = TransformIterateGhevFromBase64(
-		pair->parsedValue,
-		state->results->b.bufferTransform,
-		state->results->b.bufferTransformLength,
-		setSpecialHeadersCallback,
-		state,
-		exception);
-
-	return IS_HEADER_MATCH(
-		FIFTYONE_DEGREES_EVIDENCE_HIGH_ENTROPY_VALUES, 
-		pair) && result.iterations > 0 &&
-		(EXCEPTION_OKAY || EXCEPTION_CHECK(SUCCESS));
+    if (IS_HEADER_MATCH(
+        FIFTYONE_DEGREES_EVIDENCE_HIGH_ENTROPY_VALUES,
+        pair)) {
+        TransformIterateResult result = TransformIterateGhevFromBase64(
+            pair->parsedValue,
+            state->results->b.bufferTransform,
+            state->results->b.bufferTransformLength,
+            setSpecialHeadersCallback,
+            state,
+            exception);
+        return result.iterations > 0 && (EXCEPTION_OKAY || EXCEPTION_CHECK(SUCCESS));
+    }
+    return false;
 }
 
 // True if the header is SUA, the transform results in at least one additional 

--- a/src/hash/hash.c
+++ b/src/hash/hash.c
@@ -2652,19 +2652,22 @@ static bool setStructuredUserAgentHeader(
 	detectionComponentState* state,
 	EvidenceKeyValuePair* pair) {
 	EXCEPTION_CREATE
-	TransformIterateResult result = TransformIterateSua
-	(pair->parsedValue,
-	 state->results->b.bufferTransform,
-	 state->results->b.bufferTransformLength,
-	 setSpecialHeadersCallback,
-	 state->evidence,
-	 exception);
+    if (IS_HEADER_MATCH(
+                        FIFTYONE_DEGREES_EVIDENCE_STRUCTURED_USER_AGENT,
+                        pair)) 
+    {
+        TransformIterateResult result = TransformIterateSua
+        (pair->parsedValue,
+         state->results->b.bufferTransform,
+         state->results->b.bufferTransformLength,
+         setSpecialHeadersCallback,
+         state->evidence,
+         exception);
 
-	return IS_HEADER_MATCH(
-		FIFTYONE_DEGREES_EVIDENCE_STRUCTURED_USER_AGENT,
-		pair) &&
-		result.iterations > 0 &&
-		(EXCEPTION_OKAY || EXCEPTION_CHECK(SUCCESS));
+        return result.iterations > 0 &&
+        (EXCEPTION_OKAY || EXCEPTION_CHECK(SUCCESS));
+    }
+    return false;
 }
 
 // Checks for special evidence headers and tries to add additional headers to

--- a/src/hash/hash.h
+++ b/src/hash/hash.h
@@ -173,6 +173,7 @@
 #ifndef FIFTYONE_DEGREES_PROPERTY_LOADED
 #define FIFTYONE_DEGREES_PROPERTY_LOADED INT_MAX
 #endif
+
 /**
  * Evidence key for GetHighEntropyValues base 64 encoded JSON data.
  */

--- a/src/transform.c
+++ b/src/transform.c
@@ -124,6 +124,10 @@ static inline uint32_t base64CharToValue(
 
 static size_t base64Decode(const char* base64_input, StringBuilder *builder,
 						   StatusCode* const status) {
+    if (base64_input == NULL) {
+        *status = INVALID_INPUT;
+        return 0;
+    }
 	size_t before = builder->added;
 	size_t input_length = strlen(base64_input);
 	if (input_length % 4 != 0) {
@@ -1139,8 +1143,11 @@ static uint32_t mainParsingBody(const char* json,
 								int isSua,
 								TransformCallback callback,
 								void* ctx) {
+    if (json == NULL) {
+        *status = INVALID_INPUT;
+        return 0;
+    }
 	KeyValuePair cache[KEY_UNDEFINED];
-	
 	char *begin = builder->current;
 	// define buffer range
 	

--- a/test/EngineDeviceDetectionTests.cpp
+++ b/test/EngineDeviceDetectionTests.cpp
@@ -204,7 +204,7 @@ void EngineDeviceDetectionTests::verifyWithInvalidCharUserAgent() {
 }
 
 void EngineDeviceDetectionTests::verifyWithNullEvidence() {
-	EngineTests::verifyWithEvidence(nullptr);
+	EXPECT_THROW(EngineTests::verifyWithEvidence(nullptr), FatalException);
 }
 
 void EngineDeviceDetectionTests::verifyWithNullUserAgent() {

--- a/test/hash/ResultsHashSerializerTests.cpp
+++ b/test/hash/ResultsHashSerializerTests.cpp
@@ -34,9 +34,7 @@ public:
     virtual void SetUp();
     virtual void TearDown();
     void verify(ResultsHashSerializer &serializer, ResultsHash *results);
-
     ConfigHash *config = nullptr;
-    bool isLiteDataFile = false;
     vector<string> properties {
         "HardwareVendor",
         "HardwareName",
@@ -48,11 +46,15 @@ public:
         "IsMobile"};
     RequiredPropertiesConfig *requiredProperties = nullptr;
 
-    static constexpr auto expectedJson = "{\"BrowserName\":\"Mobile Safari\",\"BrowserVersion\":\"17.0\",\"HardwareModel\":\"iPhone\",\"HardwareName\":[\"iPhone\",\"iPhone 11\",\"iPhone 11 Pro\",\"iPhone 11 Pro Max\",\"iPhone 12\",\"iPhone 12 Pro\",\"iPhone 12 Pro Max\",\"iPhone 12 mini\",\"iPhone 13\",\"iPhone 13 Pro\",\"iPhone 13 Pro Max\",\"iPhone 13 mini\",\"iPhone 14\",\"iPhone 14 Plus\",\"iPhone 14 Pro\",\"iPhone 14 Pro Max\",\"iPhone 15\",\"iPhone 15 Plus\",\"iPhone 15 Pro\",\"iPhone 15 Pro Max\",\"iPhone 16\",\"iPhone 16 Plus\",\"iPhone 16 Pro\",\"iPhone 16 Pro Max\",\"iPhone 3G\",\"iPhone 3GS\",\"iPhone 4\",\"iPhone 4S\",\"iPhone 5\",\"iPhone 5S\",\"iPhone 5c\",\"iPhone 6\",\"iPhone 6 Plus\",\"iPhone 6s\",\"iPhone 6s Plus\",\"iPhone 7\",\"iPhone 7 Plus\",\"iPhone 8\",\"iPhone 8 Plus\",\"iPhone SE\",\"iPhone SE (2nd Gen.)\",\"iPhone SE (3rd Gen.)\",\"iPhone X\",\"iPhone XR\",\"iPhone XS\",\"iPhone XS Max\"],\"HardwareVendor\":\"Apple\",\"IsMobile\":\"True\",\"PlatformName\":\"iOS\",\"PlatformVersion\":\"17.0\"}";
+    static constexpr auto expectedJson = "{\"BrowserName\":\"Chrome\",\"BrowserVersion\":\"129\",\"HardwareModel\":\"Unknown\",\"HardwareName\":[\"Desktop\",\"Emulator\"],\"HardwareVendor\":\"Unknown\",\"IsMobile\":\"False\",\"PlatformName\":\"Windows\",\"PlatformVersion\":\"10.0\"}";
 
     static constexpr auto expectedJsonLite = "{\"BrowserName\":\"Mobile Safari\",\"BrowserVersion\":\"17.0\",\"IsMobile\":\"True\",\"PlatformName\":\"iOS\",\"PlatformVersion\":\"17.0\"}";
+    
+    static constexpr auto desktopUA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36";
+    
+    static constexpr auto mobileUA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_6_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.6668.71 Safari/537.36";
 
-    static constexpr auto mobileUA = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1";
+    const char* uaToProcess();
 };
 
 void ResultsHashSerializerTests::SetUp() {
@@ -78,8 +80,13 @@ void ResultsHashSerializerTests::verify(ResultsHashSerializer &serializer, Resul
     }
 }
 
+const char* ResultsHashSerializerTests::uaToProcess() {
+    return isLiteDataFile ? mobileUA : desktopUA;
+}
+
 TEST_F(ResultsHashSerializerTests, basicJSONSerialization) {
-    auto results = unique_ptr<ResultsHash>(getEngine()->process(mobileUA));
+    auto results = unique_ptr<ResultsHash>
+        (getEngine()->process(uaToProcess()));
     ResultsHashSerializer serializer;
     verify(serializer, results.get());
 }
@@ -87,7 +94,7 @@ TEST_F(ResultsHashSerializerTests, basicJSONSerialization) {
 TEST_F(ResultsHashSerializerTests, unhappyCases) {
     ResultsHashSerializer serializer(0); // zero buffer
     
-    auto results = unique_ptr<ResultsHash>(getEngine()->process(mobileUA));
+    auto results = unique_ptr<ResultsHash>(getEngine()->process(uaToProcess()));
     verify(serializer, results.get());
     
     ResultsHashSerializer serializer2(5); // small buffer

--- a/test/hash/SimpleEngineTestBase.cpp
+++ b/test/hash/SimpleEngineTestBase.cpp
@@ -1,0 +1,47 @@
+//
+//  EngineHashInitializer.cpp
+//  HashTests
+//
+//  Created by Eugene Dorfman on 25.10.2024.
+//
+
+#include "SimpleEngineTestBase.hpp"
+#include "../Constants.hpp"
+
+using namespace std;
+SimpleEngineTestBase::SimpleEngineTestBase() {
+
+}
+
+SimpleEngineTestBase::~SimpleEngineTestBase() {
+    deallocEngine();
+}
+
+void SimpleEngineTestBase::deallocEngine() {
+    if (engine != nullptr) {
+        delete engine;
+        engine = nullptr;
+    }
+}
+
+EngineHash *SimpleEngineTestBase::getEngine() {
+    return engine;
+}
+
+void SimpleEngineTestBase::createEngine(ConfigHash *config, 
+                                    RequiredPropertiesConfig *requiredProperties) {
+    for (int i=0;i<_HashFileNamesLength;++i) {
+        auto filePath = GetFilePath(_dataFolderName, _HashFileNames[i]);
+        try {
+            deallocEngine();
+            engine = new EngineHash(filePath, config, requiredProperties);
+            if (filePath.find("Lite") != filePath.npos) {
+                isLiteDataFile = true;
+            }
+            cout<< "filePath: "<<filePath <<" found, engine instantiated"<<endl;
+            break;
+        } catch(const StatusCodeException &exception) {
+            cout << "fileName: "<<  _HashFileNames[i] << " filePath: " << filePath << " exception code:" << exception.getCode() << endl;
+        }
+    }
+}

--- a/test/hash/SimpleEngineTestBase.cpp
+++ b/test/hash/SimpleEngineTestBase.cpp
@@ -35,9 +35,7 @@ void SimpleEngineTestBase::createEngine(ConfigHash *config,
         try {
             deallocEngine();
             engine = new EngineHash(filePath, config, requiredProperties);
-            if (filePath.find("Lite") != filePath.npos) {
-                isLiteDataFile = true;
-            }
+            isLiteDataFile = string(_HashFileNames[i]).find("Lite") != filePath.npos;
             cout<< "filePath: "<<filePath <<" found, engine instantiated"<<endl;
             break;
         } catch(const StatusCodeException &exception) {

--- a/test/hash/SimpleEngineTestBase.hpp
+++ b/test/hash/SimpleEngineTestBase.hpp
@@ -1,0 +1,35 @@
+//
+//  EngineHashInitializer.hpp
+//  HashTests
+//
+//  Created by Eugene Dorfman on 25.10.2024.
+//
+
+#ifndef EngineHashInitializer_hpp
+#define EngineHashInitializer_hpp
+#include "../../src/hash/EngineHash.hpp"
+#include "../../src/common-cxx/tests/Base.hpp"
+#include <stdio.h>
+using namespace FiftyoneDegrees::Common;
+using namespace FiftyoneDegrees::DeviceDetection;
+using namespace FiftyoneDegrees::DeviceDetection::Hash;
+
+
+class SimpleEngineTestBase: public Base{
+    EngineHash *engine = nullptr;
+    
+public:
+    SimpleEngineTestBase();
+    virtual ~SimpleEngineTestBase();
+protected:
+    EngineHash *getEngine();
+    
+    //to be used in SetUp();
+    void createEngine(ConfigHash *config, RequiredPropertiesConfig *requiredProperties);
+    
+    //can be used in TearDown(); //to prevent registering a memleak
+    void deallocEngine();
+    
+    bool isLiteDataFile;
+};
+#endif /* EngineHashInitializer_hpp */

--- a/test/hash/SuppressSnippetTests.cpp
+++ b/test/hash/SuppressSnippetTests.cpp
@@ -1,0 +1,133 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2023 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+#include "../Constants.hpp"
+#include "../../src/common-cxx/tests/Base.hpp"
+#include "../../src/hash/EngineHash.hpp"
+
+using namespace FiftyoneDegrees::Common;
+using namespace FiftyoneDegrees::DeviceDetection;
+using namespace FiftyoneDegrees::DeviceDetection::Hash;
+using namespace std;
+
+const char * SNIPPET_NAME = "JavascriptGetHighEntropyValues";
+
+class SuppressSnippetTests: public Base {
+public:
+    virtual void SetUp();
+    virtual void TearDown();
+    EvidenceDeviceDetection getEvidence();
+    
+    ConfigHash *config = nullptr;
+    RequiredPropertiesConfig *requiredProperties = nullptr;
+    EngineHash *engine = nullptr;
+    bool isLiteDataFile = false;
+    vector<string> properties {
+        "HardwareVendor",
+        "HardwareName",
+        "HardwareModel",
+        "PlatformName",
+        "PlatformVersion",
+        "BrowserName",
+        "BrowserVersion",
+        SNIPPET_NAME};
+    
+};
+void SuppressSnippetTests::TearDown() {
+    delete engine;
+    delete requiredProperties;
+    delete config;
+    Base::TearDown();
+}
+
+void SuppressSnippetTests::SetUp() {
+    Base::SetUp();
+    config = new ConfigHash();
+    requiredProperties = new RequiredPropertiesConfig(&properties);
+    for (int i=0;i<_HashFileNamesLength;++i) {
+        auto filePath = GetFilePath(_dataFolderName, _HashFileNames[i]);
+        try {
+            engine = new EngineHash(filePath, config, requiredProperties);
+            if (filePath.find("Lite") != filePath.npos) {
+                isLiteDataFile = true;
+            }
+            cout<< "filePath: "<<filePath <<" found, engine instantiated"<<endl;
+            break;
+        } catch(const StatusCodeException &exception) {
+            cout << "fileName: "<<  _HashFileNames[i] << " filePath: " << filePath << " exception code:" << exception.getCode() << endl;
+        }
+    }
+}
+
+EvidenceDeviceDetection SuppressSnippetTests::getEvidence() {
+    EvidenceDeviceDetection evidence;
+    evidence["header.user-agent"]="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36";
+    evidence["header.sec-ch-ua"]="\"Google Chrome\";v=\"129\", \"Not=A?Brand\";v=\"8\", \"Chromium\";v=\"129\"";
+    evidence["header.sec-ch-ua-mobile"]="?0";
+    evidence["header.sec-ch-ua-platform"]="\"macOS\"";
+    evidence["header.sec-ch-ua-platform-version"]="\"14.3.0\"";
+    evidence["header.sec-ch-ua-model"]="\"\"";
+    evidence["header.sec-ch-ua-full-version-list"]="\"Google Chrome\";v=\"129.0.6668.103\", \"Not=A?Brand\";v=\"8.0.0.0\", \"Chromium\";v=\"129.0.6668.103\"";
+    return evidence;
+}
+
+TEST_F(SuppressSnippetTests, snippetPresent) {
+    //Verify that JavascriptGHEV is present if at least one required UACH header
+    //was not provided
+    auto evidence = getEvidence();
+    for (auto kv : evidence) {
+        if (kv.first == "header.user-agent") {
+            continue; // try deleting any sec-ch-ua header, but not user-agent
+        }
+        auto evidence_copy = evidence;
+        evidence_copy.erase(evidence_copy.find(kv.first));
+        auto results = unique_ptr<ResultsHash>(engine->process(&evidence_copy));
+        auto value = results.get()->getValueAsString(SNIPPET_NAME);
+        EXPECT_NE(value.getValue(), ""); //snippet not empty
+    }
+}
+
+TEST_F(SuppressSnippetTests, snippetSuppressedDueToHeaders) {
+    auto evidence = getEvidence();
+    auto results = engine->process(&evidence);
+    auto value = results->getValueAsString(SNIPPET_NAME);
+    EXPECT_EQ(value.getValue(), ""); //snippet empty == suppressed
+    delete results;
+}
+
+TEST_F(SuppressSnippetTests, snippetSuppressedDueToQuery) {
+    //Verify that JavascriptGHEV is suppressed when necessary evidence is
+    //provided in a form of 51D_GetHighEntropyValues
+    
+    EvidenceDeviceDetection evidence;
+    evidence["header.user-agent"] = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36";
+
+    /*
+     {"brands":[{"brand":"Google Chrome","version":"129"},{"brand":"Not=A?Brand","version":"8"},{"brand":"Chromium","version":"129"}],"fullVersionList":[{"brand":"Google Chrome","version":"129.0.6668.103"},{"brand":"Not=A?Brand","version":"8.0.0.0"},{"brand":"Chromium","version":"129.0.6668.103"}],"mobile":false,"model":"","platform":"macOS","platformVersion":"14.3.0"}
+     */
+
+    evidence["query.51D_gethighentropyvalues"] = "eyJicmFuZHMiOlt7ImJyYW5kIjoiR29vZ2xlIENocm9tZSIsInZlcnNpb24iOiIxMjkifSx7ImJyYW5kIjoiTm90PUE/QnJhbmQiLCJ2ZXJzaW9uIjoiOCJ9LHsiYnJhbmQiOiJDaHJvbWl1bSIsInZlcnNpb24iOiIxMjkifV0sImZ1bGxWZXJzaW9uTGlzdCI6W3siYnJhbmQiOiJHb29nbGUgQ2hyb21lIiwidmVyc2lvbiI6IjEyOS4wLjY2NjguMTAzIn0seyJicmFuZCI6Ik5vdD1BP0JyYW5kIiwidmVyc2lvbiI6IjguMC4wLjAifSx7ImJyYW5kIjoiQ2hyb21pdW0iLCJ2ZXJzaW9uIjoiMTI5LjAuNjY2OC4xMDMifV0sIm1vYmlsZSI6ZmFsc2UsIm1vZGVsIjoiIiwicGxhdGZvcm0iOiJtYWNPUyIsInBsYXRmb3JtVmVyc2lvbiI6IjE0LjMuMCJ9";
+
+    auto results = engine->process(&evidence);
+    auto value = results->getValueAsString(SNIPPET_NAME);
+    EXPECT_EQ(value.getValue(), ""); //we expect snippet is suppressed
+    delete results;
+}

--- a/test/hash/SuppressSnippetTests.cpp
+++ b/test/hash/SuppressSnippetTests.cpp
@@ -103,18 +103,11 @@ TEST_F(SuppressSnippetTests, snippetSuppressedDueToHeaders) {
 }
 
 void SuppressSnippetTests::verifySuppressWithPrefix(const string &prefix) {
-    //Verify that JavascriptGHEV snippet is suppressed when necessary evidence is
-    //provided in a form of 51D_GetHighEntropyValues
+    // Verify that JavascriptGHEV snippet is suppressed when necessary evidence 
+    // is provided in a form of 51D_GetHighEntropyValues
     
-    //we signal extra capacity to be able to convert the headers
-
-    EvidenceDeviceDetection evidence(10);
+    EvidenceDeviceDetection evidence;
     evidence["header.user-agent"] = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36";
-
-    /*
-     {"brands":[{"brand":"Google Chrome","version":"129"},{"brand":"Not=A?Brand","version":"8"},{"brand":"Chromium","version":"129"}],"fullVersionList":[{"brand":"Google Chrome","version":"129.0.6668.103"},{"brand":"Not=A?Brand","version":"8.0.0.0"},{"brand":"Chromium","version":"129.0.6668.103"}],"mobile":false,"model":"","platform":"macOS","platformVersion":"14.3.0"}
-     */
-
     evidence[prefix + ".51D_gethighentropyvalues"] = "eyJicmFuZHMiOlt7ImJyYW5kIjoiR29vZ2xlIENocm9tZSIsInZlcnNpb24iOiIxMjkifSx7ImJyYW5kIjoiTm90PUE/QnJhbmQiLCJ2ZXJzaW9uIjoiOCJ9LHsiYnJhbmQiOiJDaHJvbWl1bSIsInZlcnNpb24iOiIxMjkifV0sImZ1bGxWZXJzaW9uTGlzdCI6W3siYnJhbmQiOiJHb29nbGUgQ2hyb21lIiwidmVyc2lvbiI6IjEyOS4wLjY2NjguMTAzIn0seyJicmFuZCI6Ik5vdD1BP0JyYW5kIiwidmVyc2lvbiI6IjguMC4wLjAifSx7ImJyYW5kIjoiQ2hyb21pdW0iLCJ2ZXJzaW9uIjoiMTI5LjAuNjY2OC4xMDMifV0sIm1vYmlsZSI6ZmFsc2UsIm1vZGVsIjoiIiwicGxhdGZvcm0iOiJtYWNPUyIsInBsYXRmb3JtVmVyc2lvbiI6IjE0LjMuMCJ9";
 
     auto results = getEngine()->process(&evidence);

--- a/test/hash/SuppressSnippetTests.cpp
+++ b/test/hash/SuppressSnippetTests.cpp
@@ -106,7 +106,9 @@ void SuppressSnippetTests::verifySuppressWithPrefix(const string &prefix) {
     //Verify that JavascriptGHEV snippet is suppressed when necessary evidence is
     //provided in a form of 51D_GetHighEntropyValues
     
-    EvidenceDeviceDetection evidence;
+    //we signal extra capacity to be able to convert the headers
+
+    EvidenceDeviceDetection evidence(10);
     evidence["header.user-agent"] = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36";
 
     /*

--- a/test/hash/TransformTests.cpp
+++ b/test/hash/TransformTests.cpp
@@ -1822,3 +1822,34 @@ TEST_F(Transform, GHEVBrandsEmptyArrays) {
     }
     EXPECT_FALSE(thrown);
 }
+
+TEST_F(Transform, NULLInput) {
+    const char *ghev = NULL;
+    
+    size_t bufferLength = 10;
+    char *buffer = (char *)fiftyoneDegreesMalloc(bufferLength);
+    
+    EXCEPTION_CREATE;
+    
+    fiftyoneDegreesTransformIterateResult result =
+    fiftyoneDegreesTransformIterateGhevFromBase64
+    (
+     ghev, buffer, bufferLength, fillResultsCallback, Transform::results,
+     exception);
+    EXPECT_TRUE(EXCEPTION_CHECK(FIFTYONE_DEGREES_STATUS_INVALID_INPUT));
+    EXCEPTION_CLEAR;
+    
+    result =
+    fiftyoneDegreesTransformIterateGhevFromJson
+    (ghev, buffer, bufferLength, fillResultsCallback, Transform::results,
+     exception);
+    EXPECT_TRUE(EXCEPTION_CHECK(FIFTYONE_DEGREES_STATUS_INVALID_INPUT));
+    EXCEPTION_CLEAR;
+    
+    result =
+    fiftyoneDegreesTransformIterateSua
+    (ghev, buffer, bufferLength, fillResultsCallback, Transform::results,
+     exception);
+    EXPECT_TRUE(EXCEPTION_CHECK(FIFTYONE_DEGREES_STATUS_INVALID_INPUT));
+    fiftyoneDegreesFree(buffer);
+}


### PR DESCRIPTION
Addresses #113 where GetHighEntropyValues JavaScript property values must not return JavaScript when the required evidence is already present. Needed to improve performance.
Only executed when the JavascriptGetHighEntropyValues property is a required property that can be returned. The Accept-CH properties in the DataSet are used to identify the headers that are needed for UACH/GHEV functionality. These are parsed during initialisation and stored in the device detection data set. After evidence based device detection a check is performed to determine if the evidence contains all the UACH/GHEV fields. If it does then the value returned for a subsequent call JavascriptGetHighEntropyValues will be an empty string. GettingStarted for C has been updated to better show the unpacking of evidence values to form other evidence values such as pseudo headers and UACH headers from base64.

Must be done after [common-cxx PR](https://github.com/51Degrees/common-cxx/pull/58).