### PR TITLE
Turn off `FIFTYONE_COMMON_CXX_BUILD_TESTING` (on v4.5)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,9 @@ set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
 
 # Include the common API
 
+include(CMakeDependentOption)
+cmake_dependent_option(FIFTYONE_COMMON_CXX_BUILD_TESTING "" OFF "BUILD_TESTING" OFF)
+
 include(${CMAKE_CURRENT_LIST_DIR}/src/common-cxx/CMakeLists.txt NO_POLICY_SCOPE)
 
 project(51DegreesDeviceDetection VERSION 4.0.1 LANGUAGES CXX C)


### PR DESCRIPTION
### Changes

- Add `FIFTYONE_COMMON_CXX_BUILD_TESTING` option
  - see https://github.com/51Degrees/common-cxx/pull/69
  - overrides default to always `OFF` -- even when available

This PR should be safe to merge even prior to mentioned changes to `common-cxx`, as the option value will be just unused.

### Related

- https://github.com/51Degrees/device-detection-cxx/pull/169