### PR TITLE
BUG: detection from SUA special header lead to a segfault due to passing a wrong argument

### DIFF
--- a/VisualStudio/FiftyOne.DeviceDetection.Hash.Tests/FiftyOne.DeviceDetection.Hash.Tests.vcxproj
+++ b/VisualStudio/FiftyOne.DeviceDetection.Hash.Tests/FiftyOne.DeviceDetection.Hash.Tests.vcxproj
@@ -51,7 +51,7 @@
     <ClCompile Include="..\..\test\hash\HashMemLeakReloadFromFileTests.cpp" />
     <ClCompile Include="..\..\test\hash\TransformTests.cpp" />
     <ClCompile Include="..\..\test\hash\ResultsHashSerializerTests.cpp" />
-    <ClCompile Include="..\..\test\hash\SuppressSnippetTests.cpp" />
+    <ClCompile Include="..\..\test\hash\SimpleEngineTests.cpp" />
     <ClCompile Include="..\..\test\hash\SimpleEngineTestBase.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/examples/CPP/Hash/GettingStarted.cpp
+++ b/examples/CPP/Hash/GettingStarted.cpp
@@ -166,6 +166,7 @@ namespace FiftyoneDegrees {
 
 					std::string deviceId_mobile;
 					{
+                        evidence->clear();
 						// Carries out a match for a mobile User-Agent.
 						cout << "\n";
 						cout << "Mobile User-Agent: " <<
@@ -179,6 +180,7 @@ namespace FiftyoneDegrees {
 						delete results;
 					};
 					{
+                        evidence->clear();
 						// Carries out a match for a desktop User-Agent.
 						cout << "\n[---]\n";
 						cout << "Desktop User-Agent: " <<
@@ -191,6 +193,7 @@ namespace FiftyoneDegrees {
 						delete results;
 					};
 					{
+                        evidence->clear();
 						// Carries out a match for a MediaHub User-Agent.
 						cout << "\n[---]\n";
 						cout << "MediaHub User-Agent: " <<
@@ -204,12 +207,14 @@ namespace FiftyoneDegrees {
 					};
 					std::string deviceId_hintedHub;
 					{
+                        evidence->clear();
 						// Carries out a match for a platform based on UACH headers.
 						cout << "\n(+)\n";
 						cout << "UACH Sec-CH-UA-Platform: " <<
 							uachPlatform << "\n";
 						cout << "UACH Sec-CH-UA-Platform-Version: " <<
 							uachPlatformVersion << "\n";
+                        evidence->operator[]("header.user-agent") = mediaHubUserAgent;
 						evidence->operator[]("header.Sec-CH-UA-Platform")
 							= uachPlatform;
 						evidence->operator[]("header.Sec-CH-UA-Platform-Version")
@@ -221,10 +226,11 @@ namespace FiftyoneDegrees {
 						delete results;
 					};
 					{
+                        evidence->clear();
 						// Carries out a match for a platform based on device ID.
-						cout << "\n(+)\n";
+						cout << "\n[---]\n";
 						cout << "DeviceID: " << deviceId_mobile << " -- Mobile\n";
-
+                        
 						evidence->operator[]("query.51D_deviceId")
 							= deviceId_mobile.c_str();
 
@@ -234,7 +240,8 @@ namespace FiftyoneDegrees {
 						delete results;
 					};
 					{
-						// Carries out a match for a platform with invalid device ID.
+                        evidence->clear();
+                        // Carries out a match for a platform with invalid device ID.
 						cout << "\n(+)\n";
 						const char* const deviceId_dummy = "123234-2244-1242-2412";
 						cout << "DeviceID: " << deviceId_dummy << " -- Dummy\n";
@@ -272,9 +279,11 @@ namespace FiftyoneDegrees {
 						delete evidence2;
 					};
 					{
-						// Carries out a match for a base 64 encoded GetHighEntropyValue JSON result.
-						cout << "\n(+)\n";
-						const char* const ghev_dummy = 
+                        evidence->clear();
+                        // Carries out a match for a base 64 encoded GetHighEntropyValue JSON result.
+						cout << "\n[---]\n";
+                        
+						const char* const ghev_dummy =
 							"eyJicmFuZHMiOlt7ImJyYW5kIjoiTm90L0EpQnJhbmQiLCJ2ZXJzaW9uIjoiOCJ9LHsiYnJh"
 							"bmQiOiJDaHJvbWl1bSIsInZlcnNpb24iOiIxMjYifSx7ImJyYW5kIjoiR29vZ2xlIENocm9t"
 							"ZSIsInZlcnNpb24iOiIxMjYifV0sImZ1bGxWZXJzaW9uTGlzdCI6W3siYnJhbmQiOiJOb3Qv"
@@ -291,6 +300,16 @@ namespace FiftyoneDegrees {
 						printResults(results);
 						delete results;
 					};
+                    {
+                        evidence->clear();
+                        cout <<" \n[---]\n";
+                        const char * const sua = "{\"browsers\":[{\"brand\":\"Chromium\",\"version\":[\"124\",\"0\",\"6367\",\"91\"]},{\"brand\":\"Google Chrome\",\"version\":[\"124\",\"0\",\"6367\",\"91\"]},{\"brand\":\"Not-A.Brand\",\"version\":[\"99\",\"0\",\"0\",\"0\"]}],\"platform\":{\"brand\":\"Windows\",\"version\":[\"14\",\"0\",\"0\"]},\"mobile\":0,\"architecture\":\"x86\",\"source\":2}";
+                        evidence->operator[]("query.51D_structureduseragent") = sua;
+                        cout << "SUA:" << sua << std::endl;
+                        DeviceDetection::Hash::ResultsHash* results = engine->process(evidence);
+                        printResults(results);
+                        delete results;
+                    };
 
 					// Free the evidence.
 					delete evidence;

--- a/src/hash/hash.c
+++ b/src/hash/hash.c
@@ -2670,7 +2670,7 @@ static bool setStructuredUserAgentHeader(
          state->results->b.bufferTransform,
          state->results->b.bufferTransformLength,
          setSpecialHeadersCallback,
-         state->evidence,
+         state,
          exception);
 
         return result.iterations > 0 &&

--- a/test/hash/SimpleEngineTestBase.cpp
+++ b/test/hash/SimpleEngineTestBase.cpp
@@ -1,9 +1,24 @@
-//
-//  EngineHashInitializer.cpp
-//  HashTests
-//
-//  Created by Eugene Dorfman on 25.10.2024.
-//
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2023 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
 
 #include "SimpleEngineTestBase.hpp"
 #include "../Constants.hpp"

--- a/test/hash/SimpleEngineTestBase.hpp
+++ b/test/hash/SimpleEngineTestBase.hpp
@@ -1,9 +1,24 @@
-//
-//  EngineHashInitializer.hpp
-//  HashTests
-//
-//  Created by Eugene Dorfman on 25.10.2024.
-//
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2023 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
 
 #ifndef EngineHashInitializer_hpp
 #define EngineHashInitializer_hpp


### PR DESCRIPTION
- in hash.c `setStructuredUserAgentHeader` function `state->evidence` was passed to `TransformIterateSua` routine, instead of `state`, this resulted in a segfault.  
- added basic tests for GHEV and SUA evidence processing 
- modified GettingStartedExample examples, added SUA processing