### PR TITLE
FIX: transform.c -> transformc.c

### DIFF
--- a/VisualStudio/FiftyOne.DeviceDetection.C/FiftyOne.DeviceDetection.C.vcxproj
+++ b/VisualStudio/FiftyOne.DeviceDetection.C/FiftyOne.DeviceDetection.C.vcxproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <ClCompile Include="..\..\src\dataset-dd.c" />
     <ClCompile Include="..\..\src\results-dd.c" />
-    <ClCompile Include="..\..\src\transform.c" />
+    <ClCompile Include="..\..\src\transformc.c" />
     <ClCompile Include="..\..\src\gethighentropyvalues.c" />
   </ItemGroup>
   <ItemGroup>

--- a/VisualStudio/FiftyOne.DeviceDetection.C/FiftyOne.DeviceDetection.C.vcxproj.filters
+++ b/VisualStudio/FiftyOne.DeviceDetection.C/FiftyOne.DeviceDetection.C.vcxproj.filters
@@ -38,7 +38,7 @@
     <ClCompile Include="..\..\src\results-dd.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\transform.c">
+    <ClCompile Include="..\..\src\transformc.c">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/transformc.c
+++ b/src/transformc.c
@@ -20,6 +20,17 @@
  * such notice(s) shall fulfill the requirements of that article.
  * ********************************************************************* */
 
+/*
+ * If you wanted to rename this file into `transform.c` - PLEASE DON'T!
+ * The name of the file is NOT A TYPO! 
+ * `transformc.c` is not `transform.c` because some build systems create
+ * a `transform.obj` for both `Transform.cpp` and `transform.c` in the same 
+ * directory on a case-insensitive file system. This results in a name
+ * collission and a file overwrite - as a result we get undefined symbols 
+ * during linking.  Thus to avoid such name collisions in the future 
+ * the file is named transformc.c.  
+ */
+
 #include "transform.h"
 #include "fiftyone.h"
 


### PR DESCRIPTION
to avoid .obj name collisions on some build systems writing the transform.obj for both Transform.cpp and transform.c to the same directory on a case-insensitive file system