### PR TITLE
Add special evidence keys

### DIFF
--- a/src/EngineDeviceDetection.cpp
+++ b/src/EngineDeviceDetection.cpp
@@ -36,6 +36,10 @@ void EngineDeviceDetection::init(
 	initHttpHeaderKeys(dataSet->b.uniqueHeaders);
 	initOverrideKeys(dataSet->b.overridable);
 	addKey("query.51D_deviceId");
+	addKey("query.51D_gethighentropyvalues");
+	addKey("query.51D_structureduseragent");
+	addKey("cookie.51D_gethighentropyvalues");
+	addKey("cookie.51D_structureduseragent");
 }
 
 ResultsDeviceDetection*

--- a/test/EngineDeviceDetectionTests.cpp
+++ b/test/EngineDeviceDetectionTests.cpp
@@ -307,16 +307,32 @@ void EngineDeviceDetectionTests::verifyWithEmptyUserAgent() {
 	delete results;
 }
 
-void EngineDeviceDetectionTests::verifyHasDeviceIDQueryKey() {
-	string userAgentKey = "query.51D_deviceId";
-	EngineDeviceDetection* engine = (EngineDeviceDetection*)getEngine();
+void EngineDeviceDetectionTests::verifyHasMandatoryKey(
+	const std::string &expectedKey) {
+	const auto* const engine = (EngineDeviceDetection*)getEngine();
 	const vector<string>* keys = engine->getKeys();
-	for (auto it = keys->begin(), end = keys->end(); it != end; ++it) {
-		if (!StringCompare("query.51D_deviceId", it->c_str())) {
+	for (const auto & key : *keys) {
+		if (expectedKey == key) {
 			return;
 		}
 	}
-	FAIL();
+	FAIL() << "Key not found: " << expectedKey;
+}
+
+void EngineDeviceDetectionTests::verifyHasDeviceIDQueryKey() {
+	verifyHasMandatoryKey("query.51D_deviceId");
+}
+
+void EngineDeviceDetectionTests::verifyHasEntropyKeys() {
+	const std::vector<std::string> keys {
+		"query.51D_gethighentropyvalues",
+		"query.51D_structureduseragent",
+		"cookie.51D_gethighentropyvalues",
+		"cookie.51D_structureduseragent",
+	};
+	for (const auto & key : keys) {
+		verifyHasMandatoryKey(key);
+	}
 }
 
 void EngineDeviceDetectionTests::verify() {
@@ -336,6 +352,7 @@ void EngineDeviceDetectionTests::verify() {
 	verifyUserAgentInQuery();
 	verifyValueOverride();
 	verifyHasDeviceIDQueryKey();
+	verifyHasEntropyKeys();
 }
 
 void EngineDeviceDetectionTests::userAgentPresent(const char *userAgent) {

--- a/test/EngineDeviceDetectionTests.hpp
+++ b/test/EngineDeviceDetectionTests.hpp
@@ -127,7 +127,9 @@ public:
 	void verifyWithEmptyEvidence();
 	void verifyUserAgentInQuery();
 	void verifyValueOverride();
+	void verifyHasMandatoryKey(const std::string &);
 	void verifyHasDeviceIDQueryKey();
+	void verifyHasEntropyKeys();
 	static void multiThreadRandomRunThread(void* state);
 	void multiThreadRandom(uint16_t concurrency);
 	void reloadMemory();


### PR DESCRIPTION
### Changes

- Add 4 keys to `EngineDeviceDetection`.
- Refactor `EngineDeviceDetectionTests::verifyHasDeviceIDQueryKey` and re-use for testing new keys.

### Why

- https://github.com/51Degrees/device-detection-cxx/issues/192

### Test runs

- ✅ https://github.com/postindustria-tech/device-detection-cxx/actions/runs/13187605105