### PR TITLE
disable ASAN due to failures in EngineHashTestsFileLowMemoryNull.Verify

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,9 +218,12 @@ if(BUILD_TESTING)
 		target_link_options(HashTests PRIVATE "/WX")
 	else ()
 		target_compile_options(HashTests PRIVATE ${COMPILE_OPTION_DEBUG})
-		if ((NOT TESTCOVERAGE_ENABLED) AND (NOT MINGW))
-			target_link_options(HashTests PRIVATE "-fsanitize=address")
-		endif()
+
+		# Disabling ASAN due to failures in EngineHashTestsFileLowMemoryNull.Verify on CI
+		# with AddressSanitizer:DEADLYSIGNAL SEGV on unknown address
+		# if ((NOT TESTCOVERAGE_ENABLED) AND (NOT MINGW))
+		# 	target_link_options(HashTests PRIVATE "-fsanitize=address")
+		# endif()
 	endif()
 
 	if (CMAKE_COMPILER_IS_GNUCC)


### PR DESCRIPTION
F.e. see this: https://github.com/51Degrees/device-detection-cxx/actions/runs/13488694681/job/37683403014#step:5:1669 - AddressSanitizer fails with a SEGV.  This is temporary until we find the root cause of these failures as part of #178 

cc: @drasmart - FYI