### PR TITLE
ci: add some PackageRequirements

### DIFF
--- a/ci/build-package-requirements.ps1
+++ b/ci/build-package-requirements.ps1
@@ -1,0 +1,1 @@
+Write-Host "No pre-build requirements needed"

--- a/ci/options.json
+++ b/ci/options.json
@@ -44,7 +44,8 @@
     "Configuration": "Release",
     "Arch": "x64",
     "BuildMethod": "cmake",
-    "RunPerformance": true
+    "RunPerformance": true,
+    "PackageRequirement": true
   },
   {
     "Image": "windows-latest",
@@ -59,7 +60,8 @@
     "Configuration": "Release",
     "Arch": "x86",
     "BuildMethod": "cmake",
-    "RunPerformance": true
+    "RunPerformance": true,
+    "PackageRequirement": true
   },
   {
     "Image": "ubuntu-latest",
@@ -72,7 +74,8 @@
     "Name": "Ubuntu_x86_Release",
     "Configuration": "Release",
     "Arch": "x86",
-    "RunPerformance": true
+    "RunPerformance": true,
+    "PackageRequirement": true
   },
   {
     "Image": "ubuntu-latest",
@@ -85,7 +88,8 @@
     "Name": "Ubuntu_x64_Release",
     "Configuration": "Release",
     "Arch": "x64",
-    "RunPerformance": true
+    "RunPerformance": true,
+    "PackageRequirement": true
   },
   {
     "Image": "macos-latest",


### PR DESCRIPTION
Publish now runs Compare Performance, which requires at least some options to be built.