### PR TITLE
nightly publish use full build artifact to run performance tests

### DIFF
--- a/ci/install-package.ps1
+++ b/ci/install-package.ps1
@@ -3,11 +3,16 @@ param (
 )
 
 $PackagePath = [IO.Path]::Combine($pwd, "package")
-$BuildPath = [IO.Path]::Combine($pwd, $RepoName, "build")
-$BinPath = [IO.Path]::Combine($BuildPath, "bin")
+$WorkDir = [IO.Path]::Combine($pwd, $RepoName)
+$BuildDir = [IO.Path]::Combine($WorkDir, "build")
 
-mkdir $BuildPath
 
-# Copy the prebuilt binaries to the build directory
-Copy-Item -Recurse -Path $PackagePath -Destination $BinPath
-Copy-Item -Path $PackagePath -Destination $BinPath -Recurse
+# Copy the prebuilt build dir with binaries and artifacts for tests into workdir
+Copy-Item -Path $PackagePath/* -Destination $WorkDir -Recurse
+chmod -R 777 $BuildDir
+
+Write-Output "PackagePath contents:"
+ls $PackagePath
+
+Write-Output "WorkDir contents:"
+ls $WorkDir

--- a/ci/install-package.ps1
+++ b/ci/install-package.ps1
@@ -7,8 +7,10 @@ $WorkDir = [IO.Path]::Combine($pwd, $RepoName)
 $BuildDir = [IO.Path]::Combine($WorkDir, "build")
 
 
-# Copy the prebuilt build dir with binaries and artifacts for tests into workdir
+# Copy the prebuilt build dir with binaries and artifacts for tests into workdir:
 Copy-Item -Path $PackagePath/* -Destination $WorkDir -Recurse
+
+# We probably need just execution permissions (otherwise CTest fails to run HashTests binary), 777 to not bother:
 chmod -R 777 $BuildDir
 
 Write-Output "PackagePath contents:"

--- a/ci/options.json
+++ b/ci/options.json
@@ -45,7 +45,6 @@
     "Arch": "x64",
     "BuildMethod": "cmake",
     "RunPerformance": true,
-    "PackageRequirement": true
   },
   {
     "Image": "windows-latest",
@@ -61,7 +60,6 @@
     "Arch": "x86",
     "BuildMethod": "cmake",
     "RunPerformance": true,
-    "PackageRequirement": true
   },
   {
     "Image": "ubuntu-latest",
@@ -75,7 +73,6 @@
     "Configuration": "Release",
     "Arch": "x86",
     "RunPerformance": true,
-    "PackageRequirement": true
   },
   {
     "Image": "ubuntu-latest",


### PR DESCRIPTION
https://github.com/51Degrees/common-ci/pull/166 packages the full `build` directory into an artifact which allows nightly publish to run performance tests via CTest - they are needed for the ComparePerformance test to run correctly later during Nightly Publish.