### PR TITLE
Rename private macros.

### DIFF
--- a/src/hash/hash.c
+++ b/src/hash/hash.c
@@ -135,7 +135,7 @@ if (dataSet->t == NULL) { \
  * The last byte of t is null where as keyLength is the length of printable 
  * characters. Take 1 from the t to compare length.
  */
-#define IS_HEADER_MATCH(t,p) \
+#define IS_HASH_HEADER_MATCH(t,p) \
 	(sizeof(t) - 1 == p->item.keyLength && \
 	StringCompareLength(p->item.key, t, sizeof(t)) == 0)
 
@@ -2645,7 +2645,7 @@ static bool setGetHighEntropyValuesHeader(
 	detectionComponentState* state,
 	EvidenceKeyValuePair* pair) {
 	EXCEPTION_CREATE
-    if (IS_HEADER_MATCH(
+    if (IS_HASH_HEADER_MATCH(
         FIFTYONE_DEGREES_EVIDENCE_HIGH_ENTROPY_VALUES,
         pair)) {
         TransformIterateResult result = TransformIterateGhevFromBase64(
@@ -2666,7 +2666,7 @@ static bool setStructuredUserAgentHeader(
 	detectionComponentState* state,
 	EvidenceKeyValuePair* pair) {
 	EXCEPTION_CREATE
-    if (IS_HEADER_MATCH(
+    if (IS_HASH_HEADER_MATCH(
                         FIFTYONE_DEGREES_EVIDENCE_STRUCTURED_USER_AGENT,
                         pair)) 
     {
@@ -2705,7 +2705,7 @@ static bool setResultFromDeviceId(
 	EvidenceKeyValuePair* pair) {
 
 	// Only consider the device id header.
-	if (!IS_HEADER_MATCH(FIFTYONE_DEGREES_EVIDENCE_DEVICE_ID, pair)) {
+	if (!IS_HASH_HEADER_MATCH(FIFTYONE_DEGREES_EVIDENCE_DEVICE_ID, pair)) {
 		return true; // not a match, skip
 	}
 

--- a/src/results-dd.c
+++ b/src/results-dd.c
@@ -25,7 +25,7 @@
 #include "fiftyone.h"
 #include "config-dd.h"
 
-#define CONFIG(d) ((ConfigDeviceDetection*)d->b.config)
+#define CONFIG_DD(d) ((ConfigDeviceDetection*)d->b.config)
 
 void fiftyoneDegreesResultsDeviceDetectionInit(
 	fiftyoneDegreesResultsDeviceDetection *results,
@@ -37,7 +37,7 @@ void fiftyoneDegreesResultsDeviceDetectionInit(
 	// Allocate working memory that might be used when combining header values
 	// to become pseudo headers.
 	results->bufferPseudoLength = 
-		(int)CONFIG(dataSet)->maxMatchedUserAgentLength + 1;
+		(int)CONFIG_DD(dataSet)->maxMatchedUserAgentLength + 1;
 	results->bufferPseudo = (char*)Malloc(results->bufferPseudoLength);
 
 	// Allocate working memory that might be used to transform evidence.
@@ -49,7 +49,7 @@ void fiftyoneDegreesResultsDeviceDetectionInit(
 	// applied to reduce the risk of insufficient working memory being 
 	// available.
 	results->bufferTransformLength =
-		(int)CONFIG(dataSet)->maxMatchedUserAgentLength * 2;
+		(int)CONFIG_DD(dataSet)->maxMatchedUserAgentLength * 2;
 	results->bufferTransform = (char*)Malloc(results->bufferTransformLength);
 }
 


### PR DESCRIPTION
### Changes

- Rename private macros.

### Why

- Amalgamation conflicts
  - `IS_HEADER_MATCH` in https://github.com/51Degrees/common-cxx/blob/main/overrides.c#L59
  - `CONFIG(d)` in https://github.com/51Degrees/common-cxx/blob/main/dataset.c#L27

### Related

- #311