### PR TITLE
Add UTM parameters to 51degrees.com links

### DIFF
--- a/.github/workflows/utm-link-lint.yml
+++ b/.github/workflows/utm-link-lint.yml
@@ -1,0 +1,25 @@
+name: UTM link lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  utm-link-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout common-ci
+        uses: actions/checkout@v4
+        with:
+          repository: 51Degrees/common-ci
+          path: utm-lint-common-ci
+
+      - name: Lint 51degrees.com links
+        shell: pwsh
+        run: ./utm-lint-common-ci/scripts/utm-lint.ps1 -RepoRoot .

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # 51Degrees Device Detection API
 
-![51Degrees](https://51degrees.com/DesktopModules/FiftyOne/Distributor/Logo.ashx?utm_source=github&utm_medium=repository&utm_content=home&utm_campaign=c-open-source "Data rewards the curious") **Device Detection**
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=device-detection-cxx&utm_content=readme.md&utm_term=51degrees-device-detection-api "Data rewards the curious") **Device Detection**
 
-[C Documentation](https://51degrees.com/device-detection-cxx/modules.html) and the [C++ Documentation](https://51degrees.com/device-detection-cxx/namespaces.html).
+[C Documentation](https://51degrees.com/device-detection-cxx/modules.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-cxx&utm_content=readme.md&utm_term=51degrees-device-detection-api) and the [C++ Documentation](https://51degrees.com/device-detection-cxx/namespaces.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-cxx&utm_content=readme.md&utm_term=51degrees-device-detection-api).
 
 The 51Degrees device detection API is built on the 51Degrees [common API](https://github.com/51Degrees/common-cxx).
 
@@ -14,7 +14,7 @@ In order to perform device detection, you will need to use a 51Degrees data file
 This repository includes a free, 'lite' file in the 'device-detection-data' 
 sub-module that has a significantly reduced set of properties. To obtain a 
 file with a more complete set of device properties see the 
-[51Degrees website](https://51degrees.com/pricing). 
+[51Degrees website](https://51degrees.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=device-detection-cxx&utm_content=readme.md&utm_term=data-file). 
 If you want to use the lite file, you will need to install [GitLFS](https://git-lfs.github.com/).
 
 For Linux:

--- a/ci/README.md
+++ b/ci/README.md
@@ -7,7 +7,7 @@ The following secrets are required:
     * Example: `github_pat_l0ng_r4nd0m_s7r1ng`
   
 The following secrets are required to run tests:
-* `DEVICE_DETECTION_KEY` - [license key](https://51degrees.com/pricing) for downloading assets (TAC hashes file and TAC CSV data file)
+* `DEVICE_DETECTION_KEY` - [license key](https://51degrees.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=device-detection-cxx&utm_content=ci-readme.md&utm_term=api-specific-ci-approach) for downloading assets (TAC hashes file and TAC CSV data file)
     * Example: `V3RYL0NGR4ND0M57R1NG`
  
 The following secrets are optional:

--- a/examples/C/Hash/ExampleBase.c
+++ b/examples/C/Hash/ExampleBase.c
@@ -129,7 +129,7 @@ void fiftyoneDegreesExampleCheckDataFile(
 			"https://github.com/51Degrees/device-detection-data. "
 			"Find out about the Enterprise data file, which "
 			"includes automatic daily updates, on our pricing "
-			"page: https://51degrees.com/pricing\n"), DATA_FILE_AGE_WARNING);
+			"page: https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-cxx&utm_content=examples-c-hash-examplebase.c&utm_term=data-file-age-warning\n"), DATA_FILE_AGE_WARNING);
 		printf("\033[0m");
 	}
 
@@ -138,7 +138,7 @@ void fiftyoneDegreesExampleCheckDataFile(
 			"data file. This is used for illustration, and "
 			"has limited accuracy and capabilities. Find "
 			"out about the Enterprise data file on our "
-			"pricing page: https://51degrees.com/pricing\n"));
+			"pricing page: https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-cxx&utm_content=examples-c-hash-examplebase.c&utm_term=lite-data-file\n"));
 	}
 	if (!CollectionGetIsMemoryOnly()) {
 		COLLECTION_RELEASE(dataset->strings, &item);

--- a/examples/C/Hash/GettingStarted.c
+++ b/examples/C/Hash/GettingStarted.c
@@ -54,7 +54,7 @@ static const char *dataDir = "device-detection-data";
 // Note that the Lite data file is only used for illustration, and has
 // limited accuracy and capabilities.
 // Find out about the Enterprise data file on our pricing page:
-// https://51degrees.com/pricing
+// https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-cxx&utm_content=examples-c-hash-gettingstarted.c&utm_term=top
 static const char *dataFileName = "51Degrees-LiteV4.1.hash";
 
 static char valueBuffer[1024] = "";
@@ -309,7 +309,7 @@ static void analyse(
 	// Shows the JavaScript that can be run in a User Agent Client Hint 
 	// compatible web browsers to return evidence needed for device detection
 	// as a base64 string. See 
-	// https://51degrees.com/documentation/4.4/_device_detection__features__u_a_c_h__overview.html
+	// https://51degrees.com/documentation/_device_detection__features__u_a_c_h__overview.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-cxx&utm_content=examples-c-hash-gettingstarted.c&utm_term=analyse
 	outputValue(
 		results, 
 		"GetHighEntropyValues JS", 
@@ -438,9 +438,9 @@ int main(int argc, char* argv[]) {
 	// We use the low memory profile as its performance is sufficient for this 
 	// example. See the documentation for more detail on this and other 
 	// configuration options:
-	// http://51degrees.com/documentation/_device_detection__features__performance_options.html
-	// http://51degrees.com/documentation/_features__automatic_datafile_updates.html
-	// http://51degrees.com/documentation/_features__usage_sharing.html
+	// https://51degrees.com/documentation/_device_detection__features__performance_options.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-cxx&utm_content=examples-c-hash-gettingstarted.c&utm_term=main
+	// https://51degrees.com/documentation/_features__automatic_datafile_updates.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-cxx&utm_content=examples-c-hash-gettingstarted.c&utm_term=main
+	// https://51degrees.com/documentation/_features__usage_sharing.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-cxx&utm_content=examples-c-hash-gettingstarted.c&utm_term=main
 	ConfigHash config = HashLowMemoryConfig;
 
 	// Path for the data file.

--- a/examples/C/Hash/MatchForDeviceId.c
+++ b/examples/C/Hash/MatchForDeviceId.c
@@ -102,9 +102,9 @@ Hardware-Software-Browser-Crawler.
 
 For more information on the Hash data model and how various entities 
 are related please see:
-https://51degrees.com/support/documentation/device-detection-data-model
+https://51degrees.com/support/documentation/device-detection-data-model?utm_source=code&utm_medium=example&utm_campaign=device-detection-cxx&utm_content=examples-c-hash-matchfordeviceid.c&utm_term=header
 For more information on how device detection works please see:
-https://51degrees.com/support/documentation/how-device-detection-works
+https://51degrees.com/support/documentation/how-device-detection-works?utm_source=code&utm_medium=example&utm_campaign=device-detection-cxx&utm_content=examples-c-hash-matchfordeviceid.c&utm_term=header
 */
 
 #include <stdio.h>

--- a/examples/C/Hash/MatchMetrics.c
+++ b/examples/C/Hash/MatchMetrics.c
@@ -92,7 +92,7 @@ int iterations = results->items->iterations;
 8. Obtain match method: provides information about the algorithm that was used
 to perform detection for a particular User-Agent. For more information on what
 each method means please see:
-<a href="https://51degrees.com/support/documentation/hash">
+<a href="https://51degrees.com/support/documentation/hash?utm_source=code&utm_medium=example&utm_campaign=device-detection-cxx&utm_content=examples-c-hash-matchmetrics.c&utm_term=header">
 How device detection works</a>.
 ```
 fiftyoneDegreesHashMatchMethod method = results->items->method;

--- a/examples/C/Hash/OfflineProcessing.c
+++ b/examples/C/Hash/OfflineProcessing.c
@@ -63,7 +63,7 @@ static const char *dataDir = "device-detection-data";
 //
 // Note that the Lite data file is only used for illustration, and has limited accuracy
 // and capabilities. Find out about the Enterprise data file on our pricing page:
-// https://51degrees.com/pricing
+// https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-cxx&utm_content=examples-c-hash-offlineprocessing.c&utm_term=top
 static const char *dataFileName = "51Degrees-LiteV4.1.hash";
 // This file contains the 20,000 most commonly seen combinations of header values 
 // that are relevant to device detection. For example, User-Agent and UA-CH headers.
@@ -80,9 +80,9 @@ static const size_t valueBufferLength = sizeof(valueBuffer) / sizeof(valueBuffer
 // We use the low memory profile as its performance is sufficient for this
 // example. See the documentation for more detail on this and other
 // configuration options:
-// http://51degrees.com/documentation/_device_detection__features__performance_options.html
-// http://51degrees.com/documentation/_features__automatic_datafile_updates.html
-// http://51degrees.com/documentation/_features__usage_sharing.html
+// https://51degrees.com/documentation/_device_detection__features__performance_options.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-cxx&utm_content=examples-c-hash-offlineprocessing.c&utm_term=top
+// https://51degrees.com/documentation/_features__automatic_datafile_updates.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-cxx&utm_content=examples-c-hash-offlineprocessing.c&utm_term=top
+// https://51degrees.com/documentation/_features__usage_sharing.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-cxx&utm_content=examples-c-hash-offlineprocessing.c&utm_term=top
 
 // #define CONFIG fiftyoneDegreesHashInMemoryConfig
 // #define CONFIG fiftyoneDegreesHashHighPerformanceConfig

--- a/examples/C/Hash/Performance.c
+++ b/examples/C/Hash/Performance.c
@@ -42,8 +42,8 @@
  * reduces detection time compared with requesting properties from multiple components. If you
  * don't specify any properties to detect, then all properties are detected.
  *
- * Please review [performance options](https://51degrees.com/documentation/_device_detection__features__performance_options.html)
- * and [hash dataset options](https://51degrees.com/documentation/_device_detection__hash.html#DeviceDetection_Hash_DataSetProduction_Performance)
+ * Please review [performance options](https://51degrees.com/documentation/_device_detection__features__performance_options.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-cxx&utm_content=examples-c-hash-performance.c&utm_term=header)
+ * and [hash dataset options](https://51degrees.com/documentation/_device_detection__hash.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-cxx&utm_content=examples-c-hash-performance.c&utm_term=header#DeviceDetection_Hash_DataSetProduction_Performance)
  * for more information about adjusting performance.
  *
  * This example is available in full on [GitHub](https://github.com/51Degrees/device-detection-cxx/blob/master/examples/C/Hash/Performance.c).
@@ -71,7 +71,7 @@ static const char* dataDir = "device-detection-data";
 // Note that the Lite data file is only used for illustration, and has
 // limited accuracy and capabilities.
 // Find out about the Enterprise data file on our pricing page:
-// https://51degrees.com/pricing
+// https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-cxx&utm_content=examples-c-hash-performance.c&utm_term=top
 static const char* dataFileName = "51Degrees-LiteV4.1.hash";
 
 // This file contains the 20,000 most commonly seen combinations of header 

--- a/examples/C/Hash/ReloadFromFile.c
+++ b/examples/C/Hash/ReloadFromFile.c
@@ -69,7 +69,7 @@ In a single threaded environment the reload function is executed as part of
 the normal flow of the program execution and will prevent any other actions
 until the reload is complete. The reload itself takes less than half a
 second even for Enterprise dataset. For more information see:
-https://51degrees.com/Support/Documentation/APIs/C-V32/Benchmarks
+https://51degrees.com/Support/Documentation/APIs/C-V32/Benchmarks?utm_source=code&utm_medium=example&utm_campaign=device-detection-cxx&utm_content=examples-c-hash-reloadfromfile.c&utm_term=header
 */
 
 #include <stdio.h>

--- a/examples/C/Hash/ReloadFromMemory.c
+++ b/examples/C/Hash/ReloadFromMemory.c
@@ -79,7 +79,7 @@ In a single threaded environment the reload function is executed as part of
 the normal flow of the program execution and will prevent any other actions
 until the reload is complete. The reload itself takes less than half a
 second even for Enterprise dataset. For more information see:
-https://51degrees.com/Support/Documentation/APIs/C-V32/Benchmarks
+https://51degrees.com/Support/Documentation/APIs/C-V32/Benchmarks?utm_source=code&utm_medium=example&utm_campaign=device-detection-cxx&utm_content=examples-c-hash-reloadfrommemory.c&utm_term=header
 */
 
 

--- a/examples/CPP/Hash/MatchMetrics.cpp
+++ b/examples/CPP/Hash/MatchMetrics.cpp
@@ -101,7 +101,7 @@ int iterations = results->getIterations();
 8. Obtain match method: provides information about the algorithm that was used
 to perform detection for a particular User-Agent. For more information on what
 each method means please see:
-<a href="https://51degrees.com/support/documentation/hash">
+<a href="https://51degrees.com/support/documentation/hash?utm_source=code&utm_medium=example&utm_campaign=device-detection-cxx&utm_content=examples-cpp-hash-matchmetrics.cpp&utm_term=header">
 How device detection works</a>.
 ```
 fiftyoneDegreesHashMatchMethod method = results->getMethod();

--- a/examples/CPP/Hash/ReloadFromFile.cpp
+++ b/examples/CPP/Hash/ReloadFromFile.cpp
@@ -76,7 +76,7 @@ In a single threaded environment the reload function is executed as part of
 the normal flow of the program execution and will prevent any other actions
 until the reload is complete. The reload itself takes less than half a
 second even for Enterprise dataset. For more information see:
-https://51degrees.com/Support/Documentation/APIs/C-V32/Benchmarks
+https://51degrees.com/Support/Documentation/APIs/C-V32/Benchmarks?utm_source=code&utm_medium=example&utm_campaign=device-detection-cxx&utm_content=examples-cpp-hash-reloadfromfile.cpp&utm_term=header
 */
 
 namespace FiftyoneDegrees {

--- a/examples/CPP/Hash/ReloadFromMemory.cpp
+++ b/examples/CPP/Hash/ReloadFromMemory.cpp
@@ -77,7 +77,7 @@ In a single threaded environment the reload function is executed as part of
 the normal flow of the program execution and will prevent any other actions
 until the reload is complete. The reload itself takes less than half a
 second even for Enterprise dataset. For more information see:
-https://51degrees.com/Support/Documentation/APIs/C-V32/Benchmarks
+https://51degrees.com/Support/Documentation/APIs/C-V32/Benchmarks?utm_source=code&utm_medium=example&utm_campaign=device-detection-cxx&utm_content=examples-cpp-hash-reloadfrommemory.cpp&utm_term=header
 */
 
 namespace FiftyoneDegrees {

--- a/src/hash/hash.c
+++ b/src/hash/hash.c
@@ -3823,7 +3823,7 @@ const char* fiftyoneDegreesResultsHashGetNoValueReasonMessage(
 	case FIFTYONE_DEGREES_RESULTS_NO_VALUE_REASON_NULL_PROFILE:
 	    return "No matching profiles could be found for the supplied evidence. "
 	        "A 'best guess' can be returned by configuring more lenient "
-	        "matching rules. See https://51degrees.com/documentation/_device_detection__features__false_positive_control.html";
+	        "matching rules. See https://51degrees.com/documentation/_device_detection__features__false_positive_control.html?utm_source=code&utm_medium=comment&utm_campaign=device-detection-cxx&utm_content=hash.c&utm_term=fiftyone_degrees_results_no_value_reason_null_profile";
 	case FIFTYONE_DEGREES_RESULTS_NO_VALUE_REASON_UNKNOWN:
 	default:
 		return "The reason for missing values is unknown.";

--- a/src/transform.h
+++ b/src/transform.h
@@ -39,7 +39,7 @@
  * -
  * [getHighEntropyValues()](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData/getHighEntropyValues)
  * -
- * [device.sua](https://51degrees.com/blog/openrtb-structured-user-agent-and-user-agent-client-hints)
+ * [device.sua](https://51degrees.com/blog/openrtb-structured-user-agent-and-user-agent-client-hints?utm_source=code&utm_medium=comment&utm_campaign=device-detection-cxx&utm_content=transform.h&utm_term=top)
  * - [OpenRTB 2.6
  * spec](https://iabtechlab.com/wp-content/uploads/2022/04/OpenRTB-2-6_FINAL.pdf)
  *


### PR DESCRIPTION
Apply the standard UTM vocabulary to navigational 51degrees.com links across the README, CI README, library source comments/messages, and the C/C++ examples so the Content Team can trace traffic to its exact source.

## What changed
- Tagged navigational 51degrees.com links with the five-parameter scheme (utm_source / utm_medium / utm_campaign / utm_content / utm_term).
- utm_campaign = device-detection-cxx throughout.
- Markdown -> source=github, medium=readme. Library comments/messages -> source=code, medium=comment. Files under examples/ -> source=code, medium=example.
- Runtime message strings take the message identifier as utm_term (for example the no-value-reason enum constant in hash.c, and the data-file-age-warning / lite-data-file warning messages in ExampleBase.c).
- Replaced the retired Logo.ashx URL with /img/logo.png and the new scheme.
- Normalised http -> https and removed the stale /documentation/4.4/ version segment.
- Added the shared UTM link lint workflow (.github/workflows/utm-link-lint.yml).

## Left untouched
- Functional host distributor.51degrees.com download URL (machine-fetched).
- github.com, opensource.org and other non-51degrees.com links.
- Submodule paths (src/common-cxx, device-detection-data) and copyright/license headers.

Lint passes locally (utm-lint.ps1: clean for campaign device-detection-cxx).