### PR TITLE
restore 3-arg ResultsHashCreate for HAProxy compatibility

### DIFF
--- a/src/hash/fiftyone.h
+++ b/src/hash/fiftyone.h
@@ -62,7 +62,7 @@ MAP_TYPE(HashMatchMethod)
 #define ResultsHashGetValuesStringByRequiredPropertyIndex fiftyoneDegreesResultsHashGetValuesStringByRequiredPropertyIndex /**< Synonym for #fiftyoneDegreesResultsHashGetValuesStringByRequiredPropertyIndex function. */
 #define HashGetDeviceIdFromResult fiftyoneDegreesHashGetDeviceIdFromResult /**< Synonym for #fiftyoneDegreesHashGetDeviceIdFromResult function. */
 #define HashGetDeviceIdFromResults fiftyoneDegreesHashGetDeviceIdFromResults /**< Synonym for #fiftyoneDegreesHashGetDeviceIdFromResults function. */
-#define ResultsHashCreate fiftyoneDegreesResultsHashCreate /**< Synonym for #fiftyoneDegreesResultsHashCreate function. */
+#define ResultsHashCreate(manager, overridesCapacity) fiftyoneDegreesResultsHashCreate((manager), 0, (overridesCapacity)) /**< Two argument convenience form of #fiftyoneDegreesResultsHashCreate that injects the deprecated userAgentCapacity as 0, so internal callers need not pass it. */
 #define ResultsHashFree fiftyoneDegreesResultsHashFree /**< Synonym for #fiftyoneDegreesResultsHashFree function. */
 #define ResultsHashFromDeviceId fiftyoneDegreesResultsHashFromDeviceId /**< Synonym for #fiftyoneDegreesResultsHashFromDeviceId function. */
 #define ResultsHashFromUserAgent fiftyoneDegreesResultsHashFromUserAgent /**< Synonym for #fiftyoneDegreesResultsHashFromUserAgent function. */

--- a/src/hash/hash.c
+++ b/src/hash/hash.c
@@ -3280,9 +3280,15 @@ void fiftyoneDegreesResultsHashFree(
 
 fiftyoneDegreesResultsHash* fiftyoneDegreesResultsHashCreate(
 	fiftyoneDegreesResourceManager *manager,
+	uint32_t userAgentCapacity,
 	uint32_t overridesCapacity) {
 	uint32_t i;
 	ResultsHash *results;
+
+	// Kept only so callers built against the pre-4.5 API (e.g. the HAProxy
+	// 51degrees addon) still compile; results are now sized by the number of
+	// components determined at initialisation, so this value is unused.
+	(void)userAgentCapacity;
 
 	// Increment the inUse counter for the active data set so that we can
 	// track any results that are created.

--- a/src/hash/hash.h
+++ b/src/hash/hash.h
@@ -554,12 +554,17 @@ EXTERNAL int fiftyoneDegreesResultsHashFromDeviceId(
  * process. e.g. Client Hints support.
  * @param manager pointer to the resource manager which manages a Hash data
  * set
+ * @param userAgentCapacity deprecated and ignored. Retained only so that
+ * integrations built against the pre-4.5 API (e.g. the HAProxy 51degrees
+ * addon, which still passes it) continue to compile unchanged. Results are
+ * now sized by the number of components determined at initialisation.
  * @param overridesCapacity number of properties that can be overridden,
  * 0 to disable overrides
  * @return newly created results structure
  */
 EXTERNAL fiftyoneDegreesResultsHash* fiftyoneDegreesResultsHashCreate(
 	fiftyoneDegreesResourceManager *manager,
+	uint32_t userAgentCapacity,
 	uint32_t overridesCapacity);
 
 /**


### PR DESCRIPTION
Re-adds the User-Agent capacity argument dropped in 4.5 so HAProxy's bundled 51degrees addon compiles and links against the current library again. The argument is accepted but ignored.  

HAProxy's call site: https://github.com/haproxy/haproxy/blob/1e144c488c612092067e07f18618482c64d33d17/addons/51degrees/51d.c#L479

## Changes
- Restore the deprecated `userAgentCapacity` parameter on the exported `fiftyoneDegreesResultsHashCreate`; it is `(void)` discarded since results are now sized by component count.
- Internal callers keep the two-argument form via a fixed-arity `ResultsHashCreate` macro that injects `0`- no call-site changes across the product.