### PR TITLE
FIX: Unify ResultsHash shape; drop UA fast path in FromEvidence

### DIFF
--- a/src/hash/hash.c
+++ b/src/hash/hash.c
@@ -204,15 +204,6 @@ typedef struct detection_component_state_t {
 } detectionComponentState;
 
 /**
- * State structure for checking that there is a single User-Agent string in the
- * evidence.
- */
-typedef struct detection_ua_state_t {
-	EvidenceKeyValuePair* pair;
-	int count;
-} detectionUaState;
-
-/**
  * Used to find an existing evidence pair for the header.
  */
 typedef struct set_special_headers_find_state_t {
@@ -1104,95 +1095,6 @@ static bool processRoots(
 	}
 
 	return matched;
-}
-
-static void setResultFromUserAgentComponentIndex(
-	detectionState* state,
-	uint32_t componentIndex,
-	Item* rootNodesItem,
-	uint32_t httpHeaderUniqueId) {
-	const ComponentKeyValuePair* graphKey;
-	HashRootNodes* rootNodes;
-	uint32_t headerIndex;
-	Exception* exception = state->exception;
-	Component* component = COMPONENT(state->dataSet, componentIndex);
-	bool complete = false;
-	for (headerIndex = 0;
-		EXCEPTION_OKAY &&
-		component != NULL &&
-		headerIndex < component->keyValuesCount &&
-		complete == false;
-		headerIndex++) {
-		graphKey = &(&component->firstKeyValuePair)[headerIndex];
-		if (graphKey->key == httpHeaderUniqueId) {
-			rootNodes = (HashRootNodes*)getRootNodes(
-				state->dataSet,
-				graphKey->value,
-				rootNodesItem,
-				state->exception);
-			if (rootNodes != NULL && EXCEPTION_OKAY) {
-				if (processRoots(
-					state, 
-					state->dataSet,
-					componentIndex,
-					component,
-					rootNodes) == true) {
-					addProfile(
-						state->result,
-						(byte)componentIndex,
-						state->profileOffset,
-						false);
-					complete = true;
-				}
-				COLLECTION_RELEASE(state->dataSet->rootNodes, rootNodesItem);
-			}
-		}
-	}
-}
-
-static void setResultFromUserAgent(
-	ResultHash* result,
-	DataSetHash* dataSet,
-	Exception* exception) {
-	detectionState state;
-	uint32_t componentIndex;
-	Item rootNodesItem;
-	uint32_t headerId = dataSet->b.b.uniqueHeaders->items[
-		result->b.uniqueHttpHeaderIndex].headerId;
-	DataReset(&rootNodesItem.data);
-	detectionStateInit(&state, result, dataSet, exception);
-	for (componentIndex = 0;
-		componentIndex < dataSet->componentsList.count;
-		componentIndex++) {
-		if (dataSet->componentsAvailable[componentIndex] == true) {
-			setResultFromUserAgentComponentIndex(
-				&state,
-				componentIndex,
-				&rootNodesItem,
-				headerId);
-		}
-	}
-	state.result->iterations = state.iterations;
-	state.result->drift = state.drift;
-	state.result->difference = state.difference;
-	state.result->matchedNodes = state.matchedNodes;
-	if (state.result->b.matchedUserAgent != NULL) {
-		state.result->b.matchedUserAgent[
-			MIN(state.result->b.targetUserAgentLength,
-				state.result->b.matchedUserAgentLength)] = '\0';
-	}
-	if (state.matchedNodes == 0) {
-		state.result->method = FIFTYONE_DEGREES_HASH_MATCH_METHOD_NONE;
-	}
-	else if (state.performanceMatches > 0 && state.predictiveMatches > 0) {
-		state.result->method = FIFTYONE_DEGREES_HASH_MATCH_METHOD_COMBINED;
-	}
-	else if (state.performanceMatches > 0) {
-		state.result->method = FIFTYONE_DEGREES_HASH_MATCH_METHOD_PERFORMANCE;
-	}
-	else if (state.predictiveMatches > 0) {
-		state.result->method = FIFTYONE_DEGREES_HASH_MATCH_METHOD_PREDICTIVE;
-	}
 }
 
 /**
@@ -3059,15 +2961,6 @@ static void resultsHashFromEvidence_handleAllEvidence(
 	}
 }
 
-static bool resultsHashFromEvidence_findUa(
-	void* state, 
-	EvidenceKeyValuePair *pair) {
-	detectionUaState *s = (detectionUaState*)state;
-	s->pair = pair;
-	s->count++;
-	return true;
-}
-
 static void resultsHashReset(ResultsHash* results) {
 	DataSetHash* dataSet = (DataSetHash*)results->b.b.dataSet;
 	for (uint32_t i = 0; i < results->count; i++) {
@@ -3081,38 +2974,11 @@ void fiftyoneDegreesResultsHashFromEvidence(
 	fiftyoneDegreesEvidenceKeyValuePairArray *evidence,
 	fiftyoneDegreesException *exception) {
 	DataSetHash* dataSet = (DataSetHash*)results->b.b.dataSet;
-	detectionUaState uaState = { NULL, 0 };
 
 	// Check for null evidence and set an exception if not present.
 	if (evidence == (EvidenceKeyValuePairArray*)NULL) {
 		EXCEPTION_SET(NULL_POINTER);
 		return;
-	}
-	
-	// If there is only one item of evidence and it's the User-Agent then use
-	// the simpler method that does not consider other headers, or the 
-	// possibility of profile id and device id overrides. Does not iterate the
-	// evidence as there is check to confirm only one entry.
-	EvidenceIterate(
-		evidence,
-		INT_MAX,
-		&uaState,
-		resultsHashFromEvidence_findUa);
-	if (uaState.count == 1) {
-		Header* ua = &dataSet->b.b.uniqueHeaders->items[
-			dataSet->b.uniqueUserAgentHeaderIndex];
-		if (uaState.pair->item.keyLength == ua->nameLength &&
-			StringCompareLength(
-				uaState.pair->item.key,
-				ua->name,
-				ua->nameLength) == 0) {
-			ResultsHashFromUserAgent(
-				results,
-				uaState.pair->parsedValue,
-				uaState.pair->parsedLength,
-				exception);
-			return;
-		}
 	}
 
 	// Initialise the state.
@@ -3194,22 +3060,36 @@ void fiftyoneDegreesResultsHashFromUserAgent(
 	fiftyoneDegreesException *exception) {
 	DataSetHash *dataSet = (DataSetHash*)results->b.b.dataSet;
 
-	hashResultReset(dataSet, &results->items[0]);
-	results->items[0].b.targetUserAgent = (char*)userAgent;
-	results->items[0].b.targetUserAgentLength = (int)userAgentLength;
-	results->items[0].b.uniqueHttpHeaderIndex = 
-		dataSet->b.uniqueUserAgentHeaderIndex;
-	results->count = 1;
-
-	if (results != (ResultsHash*)NULL) {
-		setResultFromUserAgent(
-			&results->items[0],
-			dataSet,
-			exception);
-		if (EXCEPTION_FAILED) {
-			return;
-		}
+	// Wrap the User-Agent in a single-pair evidence array keyed on the data
+	// set's User-Agent header and delegate to the evidence-driven detection,
+	// which is now the single detection implementation. A User-Agent processed
+	// here therefore yields exactly the same results (one item per available
+	// component) as the same User-Agent passed through ResultsHashFromEvidence.
+	// The evidence pair aliases the caller's string (parsedValue == item.value
+	// for a header prefix, no copy), so the lifetime contract is unchanged: the
+	// caller must keep userAgent alive while the results are in use.
+	Header* uaHeader = &dataSet->b.b.uniqueHeaders->items[
+		dataSet->b.uniqueUserAgentHeaderIndex];
+	EvidenceKeyValuePairArray* evidence = EvidenceCreate(1);
+	if (evidence == NULL) {
+		EXCEPTION_SET(INSUFFICIENT_MEMORY);
+		return;
 	}
+	KeyValuePair uaPair = {
+		uaHeader->name,
+		uaHeader->nameLength,
+		userAgent,
+		userAgentLength };
+	EvidenceAddPair(
+		evidence,
+		FIFTYONE_DEGREES_EVIDENCE_HTTP_HEADER_STRING,
+		uaPair);
+
+	ResultsHashFromEvidence(results, evidence, exception);
+
+	// Frees only the evidence array; the result's targetUserAgent still points
+	// at the caller-owned userAgent string, not into the freed array.
+	EvidenceFree(evidence);
 }
 
 // Adds the profile associated with the string version of the profile id 

--- a/src/hash/hash.c
+++ b/src/hash/hash.c
@@ -3068,28 +3068,32 @@ void fiftyoneDegreesResultsHashFromUserAgent(
 	// The evidence pair aliases the caller's string (parsedValue == item.value
 	// for a header prefix, no copy), so the lifetime contract is unchanged: the
 	// caller must keep userAgent alive while the results are in use.
+	//
+	// The array and its single item are built on the stack to avoid a heap
+	// allocation on this hot, UA-only detection path. EvidenceAddPair fills the
+	// item and never grows the array (capacity 1, one pair), so no 'next' block
+	// is allocated and there is nothing to free.
 	Header* uaHeader = &dataSet->b.b.uniqueHeaders->items[
 		dataSet->b.uniqueUserAgentHeaderIndex];
-	EvidenceKeyValuePairArray* evidence = EvidenceCreate(1);
-	if (evidence == NULL) {
-		EXCEPTION_SET(INSUFFICIENT_MEMORY);
-		return;
-	}
+	EvidenceKeyValuePair pairStorage;
+	EvidenceKeyValuePairArray evidence;
+	evidence.count = 0;
+	evidence.capacity = 1;
+	evidence.items = &pairStorage;
+	evidence.next = NULL;
+	evidence.prev = NULL;
+
 	KeyValuePair uaPair = {
 		uaHeader->name,
 		uaHeader->nameLength,
 		userAgent,
 		userAgentLength };
 	EvidenceAddPair(
-		evidence,
+		&evidence,
 		FIFTYONE_DEGREES_EVIDENCE_HTTP_HEADER_STRING,
 		uaPair);
 
-	ResultsHashFromEvidence(results, evidence, exception);
-
-	// Frees only the evidence array; the result's targetUserAgent still points
-	// at the caller-owned userAgent string, not into the freed array.
-	EvidenceFree(evidence);
+	ResultsHashFromEvidence(results, &evidence, exception);
 }
 
 // Adds the profile associated with the string version of the profile id 

--- a/src/hash/hash.h
+++ b/src/hash/hash.h
@@ -493,7 +493,17 @@ fiftyoneDegreesHashInitManagerFromMemory(
 
 /**
  * Processes the evidence value pairs in the evidence collection and
- * populates the result in the results structure. 
+ * populates the result in the results structure.
+ *
+ * The result shape is a deterministic function of the data set, not of how
+ * many evidence pairs are supplied. One result item is produced per available
+ * component (results->count == componentsAvailableCount when every available
+ * component resolves from the evidence, as it does for a User-Agent). Adding a
+ * redundant, lower-precedence pair that resolves to the same value (for
+ * example both 'query.user-agent' and 'header.user-agent') therefore does not
+ * change the number or layout of result items. This is the single detection
+ * entry point; ResultsHashFromUserAgent is a thin wrapper over it.
+ *
  * The 'query' and 'cookie' evidence key prefixes are used to get values which
  * dynamically override values returned from device detection. 'query' prefixes 
  * are also used in preference to 'header' for HTTP header values that are 
@@ -518,6 +528,13 @@ EXTERNAL void fiftyoneDegreesResultsHashFromEvidence(
 /**
  * Process a single User-Agent and populate the device offsets in the results
  * structure.
+ *
+ * This is a thin convenience wrapper: the User-Agent is wrapped in a
+ * single 'header.user-agent' evidence pair and passed to
+ * #fiftyoneDegreesResultsHashFromEvidence, so the result shape is identical
+ * to processing the same User-Agent as evidence (one item per available
+ * component, not a single coalesced item). The userAgent string must remain
+ * valid for the lifetime of the results, as it is referenced, not copied.
  * @param results preallocated results structure to populate
  * @param userAgent string to process
  * @param userAgentLength of the User-Agent string

--- a/test/hash/EngineHashTests.cpp
+++ b/test/hash/EngineHashTests.cpp
@@ -234,19 +234,20 @@ public:
 		// are not nulled by the forced no-match below. Turning the option off
 		// first leaves unmatched components with a null profile, so forcing
 		// matchedNodes to zero produces a fully null device id and no values.
+		// Hold the data set reference for the whole test: the config is mutated
+		// through it and must stay valid until allowUnmatched is restored below.
 		fiftyoneDegreesDataSetHash *dataSet =
 			fiftyoneDegreesDataSetHashGet(&*engine->manager);
 		// Discard the const qualifier to allow changing for the test.
 		fiftyoneDegreesConfigHash *editableConfig =
 			(fiftyoneDegreesConfigHash*)&dataSet->config;
-		fiftyoneDegreesDataSetHashRelease(dataSet);
 		bool originalAllow = editableConfig->b.allowUnmatched;
 		editableConfig->b.allowUnmatched = false;
 
 		ResultsHash *results = engine->process(mobileUserAgent);
 
 		// Force a whole-result miss: a User-Agent yields one result item per
-		// distinct header, so clear matchedNodes on every item.
+		// available component, so clear matchedNodes on every item.
 		for (uint32_t r = 0; r < results->results->count; r++) {
 			results->results->items[r].matchedNodes = 0;
 		}
@@ -265,6 +266,7 @@ public:
 			L"not valid.";
 
 		editableConfig->b.allowUnmatched = originalAllow;
+		fiftyoneDegreesDataSetHashRelease(dataSet);
 		delete results;
 	}
 

--- a/test/hash/EngineHashTests.cpp
+++ b/test/hash/EngineHashTests.cpp
@@ -223,30 +223,34 @@ public:
 		verifyPredictiveGraph();
 		verifyMatchForLowerPrecedence();
 	}
-	bool setResultsMatchedNodes(
-		ResultsHash *results,
-		int matchedNodes,
-		bool allowUnmatched) {
-		fiftyoneDegreesDataSetHash *dataSet =
-			(fiftyoneDegreesDataSetHash*)results->results->b.b.dataSet;
-		// Discard the const qualifier to allow changing for the test.
-		fiftyoneDegreesConfigHash *configSource =
-			(fiftyoneDegreesConfigHash*)&dataSet->config;
-
-		int originalAllow = configSource->b.allowUnmatched;
-
-		results->results->items->matchedNodes = matchedNodes;
-		configSource->b.allowUnmatched = allowUnmatched;
-
-		return originalAllow;
-	}
 	void verifyNoMatchedNodes() {
 		int i;
-		bool originalMatchedNodes;
 		vector<string>::iterator it;
+
+		// Disable unmatched-result defaults BEFORE detection. The unified
+		// evidence-driven detection fills components that have no matched
+		// profile with each component's default profile (flagged as
+		// overridden) when allowUnmatched is true; those overridden defaults
+		// are not nulled by the forced no-match below. Turning the option off
+		// first leaves unmatched components with a null profile, so forcing
+		// matchedNodes to zero produces a fully null device id and no values.
+		fiftyoneDegreesDataSetHash *dataSet =
+			fiftyoneDegreesDataSetHashGet(&*engine->manager);
+		// Discard the const qualifier to allow changing for the test.
+		fiftyoneDegreesConfigHash *editableConfig =
+			(fiftyoneDegreesConfigHash*)&dataSet->config;
+		fiftyoneDegreesDataSetHashRelease(dataSet);
+		bool originalAllow = editableConfig->b.allowUnmatched;
+		editableConfig->b.allowUnmatched = false;
+
 		ResultsHash *results = engine->process(mobileUserAgent);
 
-		originalMatchedNodes = setResultsMatchedNodes(results, 0, false);
+		// Force a whole-result miss: a User-Agent yields one result item per
+		// distinct header, so clear matchedNodes on every item.
+		for (uint32_t r = 0; r < results->results->count; r++) {
+			results->results->items[r].matchedNodes = 0;
+		}
+
 		for (i = 0; i < (int)results->available->count; i++) {
 			Value<string> value = results->getValueAsString(i);
 			ASSERT_FALSE(value.hasValue()) <<
@@ -259,9 +263,8 @@ public:
 		ASSERT_STREQ("0-0-0-0", results->getDeviceId().c_str()) <<
 			L"The device id should be a 'null' device id as the results are "
 			L"not valid.";
-		// Reset matched nodes in config
-		setResultsMatchedNodes(results, 0, originalMatchedNodes);
 
+		editableConfig->b.allowUnmatched = originalAllow;
 		delete results;
 	}
 

--- a/test/hash/HashCTests.cpp
+++ b/test/hash/HashCTests.cpp
@@ -146,8 +146,12 @@ TEST_F (HashCTests, ResultsHashFromDeviceIdTest) {
 		exception);
 	EXCEPTION_THROW;
 
-	EXPECT_EQ(1, resultsUserAgents->count) << "Only one results should be "
-		<< "returned.\n";
+	// A single User-Agent now yields the unified evidence-driven shape: one
+	// result item per available component, matching ResultsHashFromEvidence.
+	EXPECT_EQ(
+		((DataSetHash*)resultsUserAgents->b.b.dataSet)->componentsAvailableCount,
+		resultsUserAgents->count) << "One result per available component "
+		<< "should be returned.\n";
 	EXPECT_EQ(true, ResultsHashGetHasValues(
 		resultsUserAgents,
 		getRequiredPropertyIndex(resultsUserAgents, testPropertyName.c_str()),
@@ -196,6 +200,78 @@ TEST_F (HashCTests, ResultsHashFromDeviceIdTest) {
 	// Free the results and resource
 	ResultsHashFree(resultsUserAgents);
 	ResultsHashFree(resultsDeviceId);
+}
+
+/*
+ * Regression for issue #362. The result shape must be a function of the data
+ * set, not of evidence cardinality. A single 'header.user-agent' pair (Case A)
+ * and the same User-Agent with a redundant, lower-precedence 'query.user-agent'
+ * pair (Case B) must produce identical result counts and identify the same
+ * device. The public ResultsHashFromUserAgent entry point (Case C) must agree
+ * with them. Before the fast path was removed, Case A returned a single
+ * coalesced item while Case B returned one item per component.
+ */
+TEST_F(HashCTests, ResultsShapeIndependentOfEvidenceCardinality) {
+	EXCEPTION_CREATE;
+
+	// Case A: a single User-Agent supplied as an HTTP header.
+	EvidenceKeyValuePairArray* evidenceA = EvidenceCreate(1);
+	EvidenceAddString(
+		evidenceA,
+		FIFTYONE_DEGREES_EVIDENCE_HTTP_HEADER_STRING,
+		"User-Agent",
+		mobileUserAgent);
+	ResultsHash* resultsA = ResultsHashCreate(&manager, 0);
+	ResultsHashFromEvidence(resultsA, evidenceA, exception);
+	EXCEPTION_THROW;
+
+	// Case B: the same User-Agent plus a redundant query User-Agent. Query has
+	// precedence over header but resolves to the same string, so detection is
+	// identical; only the number of evidence pairs differs from Case A.
+	EvidenceKeyValuePairArray* evidenceB = EvidenceCreate(2);
+	EvidenceAddString(
+		evidenceB,
+		FIFTYONE_DEGREES_EVIDENCE_QUERY,
+		"User-Agent",
+		mobileUserAgent);
+	EvidenceAddString(
+		evidenceB,
+		FIFTYONE_DEGREES_EVIDENCE_HTTP_HEADER_STRING,
+		"User-Agent",
+		mobileUserAgent);
+	ResultsHash* resultsB = ResultsHashCreate(&manager, 0);
+	ResultsHashFromEvidence(resultsB, evidenceB, exception);
+	EXCEPTION_THROW;
+
+	// Case C: the public convenience entry point for a bare User-Agent.
+	ResultsHash* resultsC = ResultsHashCreate(&manager, 0);
+	ResultsHashFromUserAgent(
+		resultsC, mobileUserAgent, strlen(mobileUserAgent), exception);
+	EXCEPTION_THROW;
+
+	DataSetHash* dataSet = (DataSetHash*)resultsA->b.b.dataSet;
+	EXPECT_EQ(dataSet->componentsAvailableCount, resultsA->count) <<
+		"One result per available component should be returned.\n";
+	EXPECT_EQ(resultsA->count, resultsB->count) <<
+		"Redundant evidence must not change the result count.\n";
+	EXPECT_EQ(resultsA->count, resultsC->count) <<
+		"FromUserAgent must produce the same shape as FromEvidence.\n";
+
+	char idA[80] = "", idB[80] = "", idC[80] = "";
+	HashGetDeviceIdFromResults(resultsA, idA, sizeof(idA), exception);
+	HashGetDeviceIdFromResults(resultsB, idB, sizeof(idB), exception);
+	HashGetDeviceIdFromResults(resultsC, idC, sizeof(idC), exception);
+	EXCEPTION_THROW;
+	EXPECT_STREQ(idA, idB) <<
+		"Redundant evidence must not change the detected device.\n";
+	EXPECT_STREQ(idA, idC) <<
+		"FromUserAgent must detect the same device as FromEvidence.\n";
+
+	ResultsHashFree(resultsA);
+	ResultsHashFree(resultsB);
+	ResultsHashFree(resultsC);
+	EvidenceFree(evidenceA);
+	EvidenceFree(evidenceB);
 }
 
 /*


### PR DESCRIPTION
Removes the User-Agent fast path in ResultsHashFromEvidence so detection has one implementation. ResultsHashFromUserAgent now wraps the UA in a header.User-Agent evidence pair and delegates to ResultsHashFromEvidence. Fixes #362. Behavior note: with allowUnmatched=true, process(user-agent) now fills unmatched components with default profiles, matching process(evidence). Full HashTests suite green (937/937).